### PR TITLE
chore: migrate coverage badge to codecov

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align=center>
   <a href="https://github.com/contributte/openapi/actions"><img src="https://badgen.net/github/checks/contributte/openapi/master?cache=300"></a>
-  <a href="https://coveralls.io/r/contributte/openapi"><img src="https://badgen.net/coveralls/c/github/contributte/openapi"></a>
+  <a href="https://codecov.io/gh/contributte/openapi"><img src="https://badgen.net/codecov/c/github/contributte/openapi"></a>
   <a href="https://packagist.org/packages/contributte/openapi"> <img src="https://badgen.net/packagist/dm/contributte/openapi"> </a>
   <a href="https://packagist.org/packages/contributte/openapi"> <img src="https://badgen.net/packagist/v/contributte/openapi"> </a>
 </p>


### PR DESCRIPTION
## What changed
- replaced the README coverage badge link and image from Coveralls to Codecov
- verified the repo already uses the shared `nette-tester-coverage-v2` coverage workflow, so no workflow wiring changes were needed

## Why
- continues the Coveralls-to-Codecov migration for `contributte/openapi`
- references contributte/contributte#72