### PR TITLE
Remove phpdbg from coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ tests:
 .PHONY: coverage
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
 endif


### PR DESCRIPTION
## Summary

Switch the `coverage` target in `Makefile` from `phpdbg` to `php` so this repository matches the org-wide coverage runner update tracked in contributte/contributte#73.

## Motivation

`phpdbg` is being removed from Contributte coverage targets. This keeps `openapi` aligned with that change and lets coverage run through the standard PHP binary when a supported coverage driver is available.

## Changes

- replace `-p phpdbg` with `-p php` in both `coverage` target branches
- keep the existing coverage output behavior for local and GitHub Actions runs
- verify the regular test suite still passes after the Makefile change

## Testing

- [x] `make tests`
- [ ] `make coverage` *(fails locally: PHP has no Xdebug or PCOV extension, so code coverage is unavailable with `php` in this environment)*
- [ ] CI passes