### PR TITLE
CI: inherit secrets in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,5 +14,6 @@ jobs:
   coverage:
     name: "Nette Tester"
     uses: contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master
+    secrets: inherit
     with:
       php: "8.2"


### PR DESCRIPTION
## What changed
- Added \\`secrets: inherit\\` to the reusable coverage workflow caller in \\`.github/workflows/coverage.yml\\`.

## Why
- Ensures the shared coverage workflow receives the required secrets during CI rollout for contributte/contributte#74.