### PR TITLE
fix: OAuth flow validation contradicts the specification

### DIFF
--- a/src/Schema/OAuthFlow.php
+++ b/src/Schema/OAuthFlow.php
@@ -5,19 +5,24 @@ namespace Contributte\OpenApi\Schema;
 class OAuthFlow
 {
 
-	private string $authorizationUrl;
+	private ?string $authorizationUrl;
 
-	private string $tokenUrl;
+	private ?string $tokenUrl;
 
-	private string $refreshUrl;
+	private ?string $refreshUrl;
 
 	/** @var array<string, string> */
-	private array $scopes = [];
+	private array $scopes;
 
 	/**
 	 * @param array<string, string> $scopes
 	 */
-	public function __construct(string $authorizationUrl, string $tokenUrl, string $refreshUrl, array $scopes)
+	public function __construct(
+		?string $authorizationUrl = null,
+		?string $tokenUrl = null,
+		?string $refreshUrl = null,
+		array $scopes = [],
+	)
 	{
 		$this->authorizationUrl = $authorizationUrl;
 		$this->tokenUrl = $tokenUrl;
@@ -31,9 +36,9 @@ class OAuthFlow
 	public static function fromArray(array $data): self
 	{
 		return new self(
-			$data['authorizationUrl'],
-			$data['tokenUrl'],
-			$data['refreshUrl'],
+			$data['authorizationUrl'] ?? null,
+			$data['tokenUrl'] ?? null,
+			$data['refreshUrl'] ?? null,
 			$data['scopes'],
 		);
 	}
@@ -43,40 +48,51 @@ class OAuthFlow
 	 */
 	public function toArray(): array
 	{
-		return [
-			'authorizationUrl' => $this->authorizationUrl,
-			'tokenUrl' => $this->tokenUrl,
-			'refreshUrl' => $this->refreshUrl,
-			'scopes' => $this->scopes,
-		];
+		$data = [];
+
+		if ($this->authorizationUrl !== null) {
+			$data['authorizationUrl'] = $this->authorizationUrl;
+		}
+
+		if ($this->tokenUrl !== null) {
+			$data['tokenUrl'] = $this->tokenUrl;
+		}
+
+		if ($this->refreshUrl !== null) {
+			$data['refreshUrl'] = $this->refreshUrl;
+		}
+
+		$data['scopes'] = $this->scopes;
+
+		return $data;
 	}
 
-	public function getAuthorizationUrl(): string
+	public function getAuthorizationUrl(): ?string
 	{
 		return $this->authorizationUrl;
 	}
 
-	public function setAuthorizationUrl(string $authorizationUrl): void
+	public function setAuthorizationUrl(?string $authorizationUrl): void
 	{
 		$this->authorizationUrl = $authorizationUrl;
 	}
 
-	public function getTokenUrl(): string
+	public function getTokenUrl(): ?string
 	{
 		return $this->tokenUrl;
 	}
 
-	public function setTokenUrl(string $tokenUrl): void
+	public function setTokenUrl(?string $tokenUrl): void
 	{
 		$this->tokenUrl = $tokenUrl;
 	}
 
-	public function getRefreshUrl(): string
+	public function getRefreshUrl(): ?string
 	{
 		return $this->refreshUrl;
 	}
 
-	public function setRefreshUrl(string $refreshUrl): void
+	public function setRefreshUrl(?string $refreshUrl): void
 	{
 		$this->refreshUrl = $refreshUrl;
 	}

--- a/src/Schema/SecurityScheme.php
+++ b/src/Schema/SecurityScheme.php
@@ -230,7 +230,7 @@ class SecurityScheme
 		}
 
 		if ($this->type === self::TYPE_OAUTH2) {
-			foreach (array_keys($flows) as $flowType) {
+			foreach ($flows as $flowType => $flow) {
 				if (!in_array($flowType, self::FLOWS, true)) {
 					throw new InvalidArgumentException(sprintf(
 						'Invalid flow type "%s" given. It must be one of "%s".',
@@ -238,6 +238,8 @@ class SecurityScheme
 						implode(', ', self::FLOWS)
 					));
 				}
+
+				self::validateFlow($flowType, $flow);
 			}
 		}
 
@@ -256,6 +258,34 @@ class SecurityScheme
 		}
 
 		$this->openIdConnectUrl = $openIdConnectUrl;
+	}
+
+	private static function validateFlow(string $flowType, OAuthFlow $flow): void
+	{
+		$needsAuthorizationUrl = in_array($flowType, [
+			self::FLOW_IMPLICIT,
+			self::FLOW_AUTHORIZATION_CODE,
+		], true);
+
+		if ($needsAuthorizationUrl && $flow->getAuthorizationUrl() === null) {
+			throw new InvalidArgumentException(sprintf(
+				'Attribute "authorizationUrl" is required for flow "%s".',
+				$flowType
+			));
+		}
+
+		$needsTokenUrl = in_array($flowType, [
+			self::FLOW_PASSWORD,
+			self::FLOW_CLIENT_CREDENTIALS,
+			self::FLOW_AUTHORIZATION_CODE,
+		], true);
+
+		if ($needsTokenUrl && $flow->getTokenUrl() === null) {
+			throw new InvalidArgumentException(sprintf(
+				'Attribute "tokenUrl" is required for flow "%s".',
+				$flowType
+			));
+		}
 	}
 
 }

--- a/src/Schema/SecurityScheme.php
+++ b/src/Schema/SecurityScheme.php
@@ -204,10 +204,6 @@ class SecurityScheme
 
 	public function setBearerFormat(?string $bearerFormat): void
 	{
-		if ($this->type === self::TYPE_HTTP && $this->scheme === 'bearer' && $bearerFormat === null) {
-			throw new InvalidArgumentException('Attribute "bearerFormat" is required for type "http" and scheme "bearer".');
-		}
-
 		$this->bearerFormat = $bearerFormat;
 	}
 

--- a/src/Schema/SecurityScheme.php
+++ b/src/Schema/SecurityScheme.php
@@ -31,11 +31,16 @@ class SecurityScheme
 		self::IN_QUERY,
 	];
 
+	public const FLOW_IMPLICIT = 'implicit';
+	public const FLOW_PASSWORD = 'password';
+	public const FLOW_CLIENT_CREDENTIALS = 'clientCredentials';
+	public const FLOW_AUTHORIZATION_CODE = 'authorizationCode';
+
 	public const FLOWS = [
-		'implicit',
-		'password',
-		'clientCredentials',
-		'authorizationCode',
+		self::FLOW_IMPLICIT,
+		self::FLOW_PASSWORD,
+		self::FLOW_CLIENT_CREDENTIALS,
+		self::FLOW_AUTHORIZATION_CODE,
 	];
 
 	private string $type;
@@ -225,11 +230,12 @@ class SecurityScheme
 		}
 
 		if ($this->type === self::TYPE_OAUTH2) {
-			foreach (self::FLOWS as $flow) {
-				if (!array_key_exists($flow, $flows)) {
+			foreach (array_keys($flows) as $flowType) {
+				if (!in_array($flowType, self::FLOWS, true)) {
 					throw new InvalidArgumentException(sprintf(
-						'Attribute "flows" is missing required key "%s".',
-						$flow
+						'Invalid flow type "%s" given. It must be one of "%s".',
+						$flowType,
+						implode(', ', self::FLOWS)
 					));
 				}
 			}

--- a/tests/Cases/Schema/ExamplesTest.php
+++ b/tests/Cases/Schema/ExamplesTest.php
@@ -95,6 +95,14 @@ final class ExamplesTest extends TestCase
 		self::assertSameDataStructure($rawData, $openApiData);
 	}
 
+	public function testOauthFlows(): void
+	{
+		$rawData = Yaml::parseFile(__DIR__ . '/examples/oauth-flows-example.yaml');
+		$openApi = OpenApi::fromArray($rawData);
+		$openApiData = $openApi->toArray();
+		self::assertSameDataStructure($rawData, $openApiData);
+	}
+
 	/**
 	 * @param mixed[] $expected
 	 * @param mixed[] $actual

--- a/tests/Cases/Schema/OAuthFlowTest.php
+++ b/tests/Cases/Schema/OAuthFlowTest.php
@@ -36,6 +36,53 @@ class OAuthFlowTest extends TestCase
 		Assert::same($expectedData, OAuthFlow::fromArray($realData)->toArray());
 	}
 
+	public function testImplicitFlowWithoutTokenUrl(): void
+	{
+		$data = [
+			'authorizationUrl' => 'https://example.com/authorization',
+			'scopes' => ['read' => 'Read access'],
+		];
+
+		$flow = OAuthFlow::fromArray($data);
+
+		Assert::same('https://example.com/authorization', $flow->getAuthorizationUrl());
+		Assert::null($flow->getTokenUrl());
+		Assert::null($flow->getRefreshUrl());
+		Assert::same($data, $flow->toArray());
+	}
+
+	public function testClientCredentialsFlowWithoutAuthorizationUrl(): void
+	{
+		$data = [
+			'tokenUrl' => 'https://example.com/token',
+			'scopes' => [],
+		];
+
+		$flow = OAuthFlow::fromArray($data);
+
+		Assert::null($flow->getAuthorizationUrl());
+		Assert::same('https://example.com/token', $flow->getTokenUrl());
+		Assert::same($data, $flow->toArray());
+	}
+
+	/**
+	 * The OpenAPI Specification marks `scopes` as REQUIRED on the OAuth Flow Object (the map MAY
+	 * be empty, but the key MUST be present). fromArray() must not silently manufacture it - a
+	 * missing key has to surface as an error instead of producing an OAuthFlow with scopes = [].
+	 */
+	public function testMissingScopesIsNotSilentlyAccepted(): void
+	{
+		$data = [
+			'tokenUrl' => 'https://example.com/token',
+		];
+
+		Assert::exception(static function () use ($data): void {
+			Assert::error(static function () use ($data): void {
+				OAuthFlow::fromArray($data);
+			}, E_WARNING, 'Undefined array key "scopes"');
+		}, \TypeError::class);
+	}
+
 }
 
 (new OAuthFlowTest())->run();

--- a/tests/Cases/Schema/SecuritySchemeTest.php
+++ b/tests/Cases/Schema/SecuritySchemeTest.php
@@ -217,6 +217,52 @@ class SecuritySchemeTest extends TestCase
 		}, InvalidArgumentException::class, 'Attribute "openIdConnectUrl" is required for type "openIdConnect".');
 	}
 
+	public function testImplicitFlowRequiresAuthorizationUrl(): void
+	{
+		Assert::exception(static function (): void {
+			$securityScheme = new SecurityScheme(SecurityScheme::TYPE_OAUTH2);
+			$securityScheme->setFlows([
+				SecurityScheme::FLOW_IMPLICIT => OAuthFlow::fromArray(['scopes' => []]),
+			]);
+		}, InvalidArgumentException::class, 'Attribute "authorizationUrl" is required for flow "implicit".');
+	}
+
+	public function testClientCredentialsFlowRequiresTokenUrl(): void
+	{
+		Assert::exception(static function (): void {
+			$securityScheme = new SecurityScheme(SecurityScheme::TYPE_OAUTH2);
+			$securityScheme->setFlows([
+				SecurityScheme::FLOW_CLIENT_CREDENTIALS => OAuthFlow::fromArray(['scopes' => []]),
+			]);
+		}, InvalidArgumentException::class, 'Attribute "tokenUrl" is required for flow "clientCredentials".');
+	}
+
+	public function testAuthorizationCodeFlowRequiresBothUrls(): void
+	{
+		Assert::exception(static function (): void {
+			$securityScheme = new SecurityScheme(SecurityScheme::TYPE_OAUTH2);
+			$securityScheme->setFlows([
+				SecurityScheme::FLOW_AUTHORIZATION_CODE => OAuthFlow::fromArray([
+					'authorizationUrl' => 'https://example.com/authorization',
+					'scopes' => [],
+				]),
+			]);
+		}, InvalidArgumentException::class, 'Attribute "tokenUrl" is required for flow "authorizationCode".');
+	}
+
+	public function testRefreshUrlIsNeverRequired(): void
+	{
+		Assert::noError(static function (): void {
+			$securityScheme = new SecurityScheme(SecurityScheme::TYPE_OAUTH2);
+			$securityScheme->setFlows([
+				SecurityScheme::FLOW_PASSWORD => OAuthFlow::fromArray([
+					'tokenUrl' => 'https://example.com/token',
+					'scopes' => [],
+				]),
+			]);
+		});
+	}
+
 }
 
 (new SecuritySchemeTest())->run();

--- a/tests/Cases/Schema/SecuritySchemeTest.php
+++ b/tests/Cases/Schema/SecuritySchemeTest.php
@@ -180,19 +180,33 @@ class SecuritySchemeTest extends TestCase
 		}, InvalidArgumentException::class, 'Attribute "flows" is required for type "oauth2".');
 	}
 
-	public function testMissingFlow(): void
+	public function testSingleFlowIsAccepted(): void
+	{
+		$data = [
+			'type' => SecurityScheme::TYPE_OAUTH2,
+			'flows' => [
+				'authorizationCode' => [
+					'authorizationUrl' => 'https://example.com/authorization',
+					'tokenUrl' => 'https://example.com/token',
+					'scopes' => ['read' => 'Read access'],
+				],
+			],
+		];
+
+		Assert::same($data, SecurityScheme::fromArray($data)->toArray());
+	}
+
+	public function testUnknownFlowTypeIsRejected(): void
 	{
 		Assert::exception(static function (): void {
 			$securityScheme = new SecurityScheme(SecurityScheme::TYPE_OAUTH2);
 			$securityScheme->setFlows([
-				'implicit' => OAuthFlow::fromArray([
+				'telepathy' => OAuthFlow::fromArray([
 					'authorizationUrl' => 'https://example.com/authorization',
-					'tokenUrl' => 'https://example.com/token',
-					'refreshUrl' => 'https://example.com/refresh',
-					'scopes' => ['read' => 'Read access', 'write' => 'Write access'],
+					'scopes' => [],
 				]),
 			]);
-		}, InvalidArgumentException::class, 'Attribute "flows" is missing required key "password".');
+		}, InvalidArgumentException::class, 'Invalid flow type "telepathy" given. It must be one of "implicit, password, clientCredentials, authorizationCode".');
 	}
 
 	public function testMissingOpenIdConnectUrl(): void

--- a/tests/Cases/Schema/SecuritySchemeTest.php
+++ b/tests/Cases/Schema/SecuritySchemeTest.php
@@ -158,13 +158,18 @@ class SecuritySchemeTest extends TestCase
 		}, InvalidArgumentException::class, 'Attribute "scheme" is required for type "http".');
 	}
 
-	public function testMissingBearerFormat(): void
+	public function testBearerFormatIsOptional(): void
 	{
-		Assert::exception(static function (): void {
-			$securityScheme = new SecurityScheme(SecurityScheme::TYPE_HTTP);
-			$securityScheme->setScheme('bearer');
-			$securityScheme->setBearerFormat(null);
-		}, InvalidArgumentException::class, 'Attribute "bearerFormat" is required for type "http" and scheme "bearer".');
+		$data = [
+			'type' => SecurityScheme::TYPE_HTTP,
+			'scheme' => 'bearer',
+		];
+
+		Assert::noError(static function () use ($data): void {
+			SecurityScheme::fromArray($data);
+		});
+
+		Assert::same($data, SecurityScheme::fromArray($data)->toArray());
 	}
 
 	public function testMissingFlows(): void

--- a/tests/Cases/Schema/examples/oauth-flows-example.yaml
+++ b/tests/Cases/Schema/examples/oauth-flows-example.yaml
@@ -1,0 +1,21 @@
+openapi: 3.1.0
+info:
+  title: OAuth Flows Example
+  version: 1.0.0
+paths: {}
+components:
+  securitySchemes:
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: https://example.com/api/oauth/dialog
+          scopes:
+            "write:pets": modify pets in your account
+            "read:pets": read your pets
+        authorizationCode:
+          authorizationUrl: https://example.com/api/oauth/dialog
+          tokenUrl: https://example.com/api/oauth/token
+          scopes:
+            "write:pets": modify pets in your account
+            "read:pets": read your pets


### PR DESCRIPTION
## Problem

The library rejects OAuth security schemes that the specification permits — including the **official OAuth Flow Object Example from the specification itself**:

```
TypeError: OAuthFlow::__construct(): Argument #2 ($tokenUrl) must be of type string, null given
```

Three defects cause this. All three contradict tables that are identical in OAS 3.0.4 and 3.1.1, so 3.0 documents are affected too.

**1. `OAuthFlow` treated every field as mandatory.** Only `scopes` is REQUIRED; for the URLs the "Applies To" column narrows the rest:

| Field | Required? | Applies to |
|-------|-----------|------------|
| `authorizationUrl` | REQUIRED | `implicit`, `authorizationCode` only |
| `tokenUrl` | REQUIRED | `password`, `clientCredentials`, `authorizationCode` only |
| `refreshUrl` | not required | any `oauth2` |
| `scopes` | REQUIRED | any `oauth2` — "The map MAY be empty" |

All four were declared `string` and read unconditionally, so an implicit flow — which has no token endpoint by definition — could not be represented at all.

**2. `oauth2` required all four flow types at once.** The OAuth Flows Object marks no field as REQUIRED, yet a scheme supporting only `authorizationCode` was rejected with `Attribute "flows" is missing required key "implicit".`

**3. `bearerFormat` was required for `http`/`bearer` schemes.** The specification calls it a hint "primarily for documentation purposes". It is not REQUIRED, yet omitting it threw.

## Changes

- **`OAuthFlow`** — the three URL fields become nullable and `toArray()` emits only what is set. `scopes` stays mandatory, read unguarded like the required fields of `Info`, `Server` and `Tag`.
- **`SecurityScheme::setFlows()`** — accepts any non-empty subset of known flow types and validates each flow's URLs against its own type: `implicit` needs `authorizationUrl`, `password` and `clientCredentials` need `tokenUrl`, `authorizationCode` needs both, `refreshUrl` is never required. Unknown flow keys are still rejected; an `oauth2` scheme with no flows at all is still invalid.
- **`SecurityScheme::setBearerFormat()`** — validation removed.
- Named `FLOW_*` constants added, following the existing `TYPE_*`/`IN_*` pattern. `FLOWS` keeps its value and order.

Per-flow validation lives in `SecurityScheme` because only it knows which flow type a given `OAuthFlow` represents.

Two limits are deliberate: the "Applies to" column is enforced in one direction only (a flow carrying a URL it does not need is still accepted, since tightening that breaks the existing `testRequired` provider), and `flows: {}` still throws even though an empty map validates against the official schema — both are BC decisions of their own.

## Backward compatibility

`getAuthorizationUrl()`, `getTokenUrl()` and `getRefreshUrl()` now return `?string`, so callers feeding them into a `string` parameter need a null check. Unavoidable — the fields are genuinely optional. Everything else is source-compatible: constructor parameter order is unchanged and all four arguments now have defaults.

## Tests

Eleven tests added, each failing against the unmodified code. Two tests that asserted the removed behaviour were replaced (`testMissingBearerFormat` → `testBearerFormatIsOptional`; `testMissingFlow` → `testSingleFlowIsAccepted` + `testUnknownFlowTypeIsRejected`). `testMissingFlows` is retained — that case is still invalid. The specification's OAuth Flow Object Example is added as a round-trip fixture, verified to fail against the pre-fix code.
