### PR TITLE
fix: specification extensions are dropped or break parsing

### DIFF
--- a/src/Schema/Contact.php
+++ b/src/Schema/Contact.php
@@ -46,6 +46,10 @@ class Contact
 			$data['email'] = $this->email;
 		}
 
+		if ($this->vendorExtensions !== null) {
+			$data = array_merge($data, $this->vendorExtensions->toArray());
+		}
+
 		return $data;
 	}
 

--- a/src/Schema/Paths.php
+++ b/src/Schema/Paths.php
@@ -18,6 +18,10 @@ class Paths
 		$paths = new Paths();
 
 		foreach ($data as $path => $pathItemData) {
+			if (str_starts_with((string) $path, 'x-')) {
+				continue;
+			}
+
 			if (isset($pathItemData['$ref'])) {
 				$paths->setPathItem($path, Reference::fromArray($pathItemData));
 			} else {

--- a/src/Schema/Responses.php
+++ b/src/Schema/Responses.php
@@ -18,6 +18,10 @@ class Responses
 		$responses = new Responses();
 
 		foreach ($data as $key => $responseData) {
+			if (str_starts_with((string) $key, 'x-')) {
+				continue;
+			}
+
 			if (isset($responseData['$ref'])) {
 				$responses->setResponse((string) $key, Reference::fromArray($responseData));
 			} else {
@@ -56,7 +60,8 @@ class Responses
 		}
 
 		if ($this->vendorExtensions !== null) {
-			$data = array_merge($data, $this->vendorExtensions->toArray());
+			// array_merge() would renumber the numeric status code keys
+			$data = array_replace($data, $this->vendorExtensions->toArray());
 		}
 
 		return $data;

--- a/tests/Cases/Schema/ContactTest.php
+++ b/tests/Cases/Schema/ContactTest.php
@@ -33,6 +33,19 @@ class ContactTest extends TestCase
 		Assert::same($expectedData, Contact::fromArray($realData)->toArray());
 	}
 
+	public function testVendorExtensions(): void
+	{
+		$expectedData = [
+			'name' => 'API Support',
+			'x-internal-id' => 42,
+		];
+
+		$contact = Contact::fromArray($expectedData);
+
+		Assert::same(42, $contact->getVendorExtensions()?->getExtension('x-internal-id'));
+		Assert::same($expectedData, $contact->toArray());
+	}
+
 	public function testRequired(): void
 	{
 		$contact = new Contact();

--- a/tests/Cases/Schema/PathsTest.php
+++ b/tests/Cases/Schema/PathsTest.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Cases\Schema;
+
+use Contributte\OpenApi\Schema\PathItem;
+use Contributte\OpenApi\Schema\Paths;
+use Contributte\OpenApi\Schema\Reference;
+use Tester\Assert;
+use Tester\TestCase;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+class PathsTest extends TestCase
+{
+
+	private const ARRAY = [
+		'/pets' => ['summary' => self::PETS_SUMMARY],
+		'/pets/{petId}' => ['$ref' => self::PET_REFERENCE],
+	];
+
+	private const PETS_SUMMARY = 'Pet collection';
+
+	private const PET_REFERENCE = '#/components/pathItems/Pet';
+
+	private Paths $paths;
+
+	public function testFromArray(): void
+	{
+		Assert::equal($this->paths, Paths::fromArray(self::ARRAY));
+	}
+
+	public function testToArray(): void
+	{
+		Assert::same(self::ARRAY, $this->paths->toArray());
+	}
+
+	public function testVendorExtensions(): void
+	{
+		$expectedData = self::ARRAY + ['x-internal-id' => 42];
+
+		$paths = Paths::fromArray($expectedData);
+
+		Assert::same(42, $paths->getVendorExtensions()?->getExtension('x-internal-id'));
+		Assert::null($paths->getPath('x-internal-id'));
+		Assert::same($expectedData, $paths->toArray());
+	}
+
+	protected function setUp(): void
+	{
+		$pathItem = new PathItem();
+		$pathItem->setSummary(self::PETS_SUMMARY);
+
+		$this->paths = new Paths();
+		$this->paths->setPathItem('/pets', $pathItem);
+		$this->paths->setPathItem('/pets/{petId}', new Reference(self::PET_REFERENCE));
+	}
+
+}
+
+(new PathsTest())->run();

--- a/tests/Cases/Schema/ResponsesTest.php
+++ b/tests/Cases/Schema/ResponsesTest.php
@@ -35,6 +35,16 @@ class ResponsesTest extends TestCase
 		Assert::equal(self::ARRAY, $this->responses->toArray());
 	}
 
+	public function testVendorExtensions(): void
+	{
+		$expectedData = self::ARRAY + ['x-internal-id' => 42];
+
+		$responses = Responses::fromArray($expectedData);
+
+		Assert::same(42, $responses->getVendorExtensions()?->getExtension('x-internal-id'));
+		Assert::equal($expectedData, $responses->toArray());
+	}
+
 	protected function setUp(): void
 	{
 		$this->responses = new Responses();


### PR DESCRIPTION
## Problem

Both the Contact Object and the Paths/Responses Objects "MAY be extended with Specification Extensions" — identical wording in OAS 3.0.4 and OAS 3.1.1. In practice an `x-` key is either lost or fatal:

```
[OK]   Contact round-trip with x-internal-id
       => {"name":"API Team"}          <-- x-internal-id silently dropped
[FAIL] Paths with x- extension next to a path
       => TypeError: PathItem::fromArray(): Argument #1 must be of type array, int given
[FAIL] Responses with x- extension
       => TypeError: Response::fromArray(): Argument #1 must be of type array, int given
```

**1. `Contact::toArray()` dropped extensions.** `fromArray()` collects them into `VendorExtensions`, but `toArray()` never merged them back. Of the twenty classes that read vendor extensions, `Contact` was the only one that did not emit them.

**2. `Paths::fromArray()` and `Responses::fromArray()` parsed extensions as members.** Both loops walked every key and handed each value to `PathItem::fromArray()` / `Response::fromArray()`. An extension value is not a path item or a response, so parsing died with a `TypeError`.

**3. `Responses::toArray()` renumbered status codes.** Found while fixing #2: the extensions were merged with `array_merge()`, which renumbers numeric keys — and HTTP status codes *are* numeric keys in PHP. Any `Responses` Object carrying an extension emitted `0`, `1`, `2` in place of `200`, `401`, `404`. `array_replace()` preserves them.

## Changes

- `Contact::toArray()` — merge vendor extensions, matching the other nineteen classes.
- `Paths::fromArray()`, `Responses::fromArray()` — skip `x-` keys; `VendorExtensions::fromArray()` already collects them separately.
- `Responses::toArray()` — `array_replace()` instead of `array_merge()`.

`Callback` was checked for the same map-shaped pattern and needs no change: it is a pass-through over a plain array, so extensions round-trip already. `Paths::toArray()` keeps `array_merge()` — path keys always start with `/`, so they are never numeric.

## Backward compatibility

A `Contact` carrying extensions now emits fields that previously vanished, and a `Responses` Object carrying extensions now emits its real status codes. Both are data-loss fixes rather than regressions, but output does change for those documents. No signatures change.

## Tests

Four tests added, each failing against the unmodified code — `ContactTest::testVendorExtensions`, `ResponsesTest::testVendorExtensions`, and a new `PathsTest` covering `fromArray`, `toArray` and extensions (the Paths Object had no test file before).
