### PR TITLE
feat: report constructs that do not match the declared version

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -66,6 +66,9 @@ foreach ((new VersionValidator())->validate($openApi) as $problem) {
 Problems are returned, never thrown. Each one carries a level (`Problem::LEVEL_WARNING` or
 `Problem::LEVEL_ERROR`), a dot-separated path and a message.
 
+A document that declares no version is read as `Version::DEFAULT`, which is 3.0 - the
+version this library implemented before it could tell versions apart.
+
 `Version` compares version strings on their own:
 
 ```php

--- a/.docs/README.md
+++ b/.docs/README.md
@@ -6,6 +6,7 @@ Pure PHP OpenAPI 3.0 implementation for Nette Framework.
 
 - [Setup](#setup)
 - [OpenAPI](#tracy)
+- [Version validation](#version-validation)
 - [Tracy](#tracy)
 
 ## Setup
@@ -44,6 +45,35 @@ composer require contributte/openapi
 - [Server.php](../src/Schema/Server.php)
 - [ServerVariable.php](../src/Schema/ServerVariable.php)
 - [Tag.php](../src/Schema/Tag.php)
+
+## Version validation
+
+The schema classes accept any document, whatever version it declares. `VersionValidator`
+reports constructs that do not belong to that version - for example a 3.0 document using
+`webhooks`, which was introduced in 3.1.
+
+```php
+use Contributte\OpenApi\Schema\OpenApi;
+use Contributte\OpenApi\Validator\VersionValidator;
+
+$openApi = OpenApi::fromArray($data);
+
+foreach ((new VersionValidator())->validate($openApi) as $problem) {
+	echo $problem; // [warning] webhooks: Attribute "webhooks" was introduced in OpenAPI 3.1, but the document declares 3.0.
+}
+```
+
+Problems are returned, never thrown. Each one carries a level (`Problem::LEVEL_WARNING` or
+`Problem::LEVEL_ERROR`), a dot-separated path and a message.
+
+`Version` compares version strings on their own:
+
+```php
+use Contributte\OpenApi\Version;
+
+Version::match('3.0.4', '3.0.x'); // true
+Version::isSupported('3.1.1');    // true
+```
 
 ## Tracy
 

--- a/src/Validator/Problem.php
+++ b/src/Validator/Problem.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\OpenApi\Validator;
+
+class Problem
+{
+
+	public const LEVEL_WARNING = 'warning';
+	public const LEVEL_ERROR = 'error';
+
+	public function __construct(
+		private string $level,
+		private string $path,
+		private string $message,
+	)
+	{
+	}
+
+	public function getLevel(): string
+	{
+		return $this->level;
+	}
+
+	/**
+	 * Dot-separated location of the problem within the document, for example
+	 * "components.securitySchemes.petstore_auth.type".
+	 */
+	public function getPath(): string
+	{
+		return $this->path;
+	}
+
+	public function getMessage(): string
+	{
+		return $this->message;
+	}
+
+	public function __toString(): string
+	{
+		return sprintf('[%s] %s: %s', $this->level, $this->path, $this->message);
+	}
+
+}

--- a/src/Validator/VersionValidator.php
+++ b/src/Validator/VersionValidator.php
@@ -1,0 +1,164 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\OpenApi\Validator;
+
+use Contributte\OpenApi\Schema\OpenApi;
+use Contributte\OpenApi\Schema\SecurityScheme;
+use Contributte\OpenApi\Version;
+
+/**
+ * Reports constructs that do not belong to the version the document declares.
+ *
+ * Every rule is a table entry of "document path => version", so supporting a new
+ * OpenAPI version means adding rows, not methods.
+ *
+ * Problems are returned, never thrown: a library has no control over the documents
+ * handed to it, and refusing to parse is worse than reporting.
+ */
+class VersionValidator
+{
+
+	/**
+	 * Fields and the version that introduced them. A "*" segment matches any key
+	 * of a map.
+	 */
+	private const FIELD_INTRODUCED_IN = [
+		'jsonSchemaDialect' => Version::V3_1,
+		'webhooks' => Version::V3_1,
+		'info.summary' => Version::V3_1,
+		'info.license.identifier' => Version::V3_1,
+		'components.pathItems' => Version::V3_1,
+	];
+
+	/**
+	 * Field values and the version that introduced them, as
+	 * "document path => [value => version]".
+	 */
+	private const VALUE_INTRODUCED_IN = [
+		'components.securitySchemes.*.type' => [
+			SecurityScheme::TYPE_MUTUAL_TLS => Version::V3_1,
+		],
+	];
+
+	/**
+	 * Required fields and the version that made them optional.
+	 */
+	private const FIELD_OPTIONAL_SINCE = [
+		'paths' => Version::V3_1,
+	];
+
+	/**
+	 * @return Problem[]
+	 */
+	public function validate(OpenApi $openApi): array
+	{
+		$data = $openApi->toArray();
+		$version = is_string($data['openapi'] ?? null) ? $data['openapi'] : '';
+
+		if (!Version::isSupported($version)) {
+			return [
+				new Problem(
+					Problem::LEVEL_WARNING,
+					'openapi',
+					sprintf(
+						'Unsupported OpenAPI version "%s". Supported versions are "%s".',
+						$version,
+						implode('", "', Version::SUPPORTED)
+					)
+				),
+			];
+		}
+
+		$problems = [];
+
+		foreach (self::FIELD_INTRODUCED_IN as $path => $introducedIn) {
+			if (!Version::isBefore($version, $introducedIn)) {
+				continue;
+			}
+
+			foreach (array_keys(self::collect($data, $path)) as $foundPath) {
+				$problems[] = self::introducedIn($foundPath, $introducedIn, $version);
+			}
+		}
+
+		foreach (self::VALUE_INTRODUCED_IN as $path => $values) {
+			foreach (self::collect($data, $path) as $foundPath => $foundValue) {
+				foreach ($values as $value => $introducedIn) {
+					if ($foundValue === $value && Version::isBefore($version, $introducedIn)) {
+						$problems[] = self::introducedIn($foundPath, $introducedIn, $version);
+					}
+				}
+			}
+		}
+
+		foreach (self::FIELD_OPTIONAL_SINCE as $path => $optionalSince) {
+			if (!Version::isBefore($version, $optionalSince) || self::collect($data, $path) !== []) {
+				continue;
+			}
+
+			$problems[] = new Problem(
+				Problem::LEVEL_ERROR,
+				$path,
+				sprintf(
+					'Attribute "%s" is required in OpenAPI %s. It became optional in %s.',
+					$path,
+					$version,
+					$optionalSince
+				)
+			);
+		}
+
+		return $problems;
+	}
+
+	private static function introducedIn(string $path, string $introducedIn, string $version): Problem
+	{
+		return new Problem(
+			Problem::LEVEL_WARNING,
+			$path,
+			sprintf(
+				'Attribute "%s" was introduced in OpenAPI %s, but the document declares %s.',
+				$path,
+				$introducedIn,
+				$version
+			)
+		);
+	}
+
+	/**
+	 * Resolves a dot-separated path, expanding "*" into every key of the map it
+	 * stands for, and returns the concrete paths that exist mapped to their values.
+	 *
+	 * @param mixed[] $data
+	 * @return array<string, mixed>
+	 */
+	private static function collect(array $data, string $path): array
+	{
+		$found = ['' => $data];
+
+		foreach (explode('.', $path) as $segment) {
+			$next = [];
+
+			foreach ($found as $prefix => $value) {
+				if (!is_array($value)) {
+					continue;
+				}
+
+				$keys = $segment === '*' ? array_keys($value) : [$segment];
+
+				foreach ($keys as $key) {
+					if (!array_key_exists($key, $value)) {
+						continue;
+					}
+
+					$next[$prefix === '' ? (string) $key : $prefix . '.' . $key] = $value[$key];
+				}
+			}
+
+			$found = $next;
+		}
+
+		return $found;
+	}
+
+}

--- a/src/Validator/VersionValidator.php
+++ b/src/Validator/VersionValidator.php
@@ -54,8 +54,17 @@ class VersionValidator
 	{
 		$data = $openApi->toArray();
 		$version = is_string($data['openapi'] ?? null) ? $data['openapi'] : '';
+		$problems = [];
 
-		if (!Version::isSupported($version)) {
+		if ($version === '') {
+			$problems[] = new Problem(
+				Problem::LEVEL_WARNING,
+				'openapi',
+				sprintf('No OpenAPI version declared. Reading the document as %s.', Version::DEFAULT)
+			);
+
+			$version = Version::DEFAULT;
+		} elseif (!Version::isSupported($version)) {
 			return [
 				new Problem(
 					Problem::LEVEL_WARNING,
@@ -68,8 +77,6 @@ class VersionValidator
 				),
 			];
 		}
-
-		$problems = [];
 
 		foreach (self::FIELD_INTRODUCED_IN as $path => $introducedIn) {
 			if (!Version::isBefore($version, $introducedIn)) {

--- a/src/Version.php
+++ b/src/Version.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\OpenApi;
+
+class Version
+{
+
+	public const V3_0 = '3.0';
+	public const V3_1 = '3.1';
+
+	public const SUPPORTED = [
+		self::V3_0,
+		self::V3_1,
+	];
+
+	/**
+	 * Compares a version against a pattern. A pattern segment of "x" or "*" matches
+	 * anything, and segments the pattern does not mention are ignored, so both
+	 * "3.0.4" and "3.0" match the pattern "3.0.x".
+	 */
+	public static function match(string $version, string $pattern): bool
+	{
+		$versionSegments = explode('.', $version);
+
+		foreach (explode('.', $pattern) as $index => $patternSegment) {
+			if ($patternSegment === 'x' || $patternSegment === '*') {
+				continue;
+			}
+
+			if (($versionSegments[$index] ?? null) !== $patternSegment) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Whether the version precedes the other one. Missing segments count as zero,
+	 * so "3.0.4" precedes "3.1" and "3.1.1" does not.
+	 */
+	public static function isBefore(string $version, string $other): bool
+	{
+		return version_compare($version, $other, '<');
+	}
+
+	public static function isSupported(string $version): bool
+	{
+		foreach (self::SUPPORTED as $supported) {
+			if (self::match($version, $supported)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+}

--- a/src/Version.php
+++ b/src/Version.php
@@ -8,6 +8,12 @@ class Version
 	public const V3_0 = '3.0';
 	public const V3_1 = '3.1';
 
+	/**
+	 * The version assumed when a document declares none. The library implemented 3.0
+	 * before it could tell versions apart, so such documents keep being read as 3.0.
+	 */
+	public const DEFAULT = self::V3_0;
+
 	public const SUPPORTED = [
 		self::V3_0,
 		self::V3_1,

--- a/tests/Cases/Validator/VersionValidatorTest.php
+++ b/tests/Cases/Validator/VersionValidatorTest.php
@@ -1,0 +1,146 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Cases\Validator;
+
+use Contributte\OpenApi\Schema\OpenApi;
+use Contributte\OpenApi\Validator\Problem;
+use Contributte\OpenApi\Validator\VersionValidator;
+use Tester\Assert;
+use Tester\TestCase;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+class VersionValidatorTest extends TestCase
+{
+
+	private const INFO = ['title' => 'Test API', 'version' => '1.0.0'];
+
+	private VersionValidator $validator;
+
+	public function testSupportedDocumentsWithoutProblems(): void
+	{
+		Assert::same([], $this->validate(['openapi' => '3.0.4', 'info' => self::INFO, 'paths' => []]));
+		Assert::same([], $this->validate(['openapi' => '3.1.1', 'info' => self::INFO]));
+	}
+
+	public function testUnsupportedVersionIsReported(): void
+	{
+		$problems = $this->validate(['openapi' => '2.0', 'info' => self::INFO, 'paths' => []]);
+
+		Assert::same(['warning openapi'], $this->summarize($problems));
+		Assert::contains('2.0', $problems[0]->getMessage());
+	}
+
+	public function testFieldsIntroducedLater(): void
+	{
+		Assert::same(['warning jsonSchemaDialect'], $this->summarize($this->validate([
+			'openapi' => '3.0.4',
+			'info' => self::INFO,
+			'paths' => [],
+			'jsonSchemaDialect' => 'https://json-schema.org/draft/2020-12/schema',
+		])));
+
+		Assert::same(['warning webhooks'], $this->summarize($this->validate([
+			'openapi' => '3.0.4',
+			'info' => self::INFO,
+			'paths' => [],
+			'webhooks' => ['newPet' => ['summary' => 'New pet']],
+		])));
+	}
+
+	public function testNestedFieldsIntroducedLater(): void
+	{
+		Assert::same(['warning info.summary'], $this->summarize($this->validate([
+			'openapi' => '3.0.4',
+			'info' => self::INFO + ['summary' => 'A short summary'],
+			'paths' => [],
+		])));
+
+		Assert::same(['warning info.license.identifier'], $this->summarize($this->validate([
+			'openapi' => '3.0.4',
+			'info' => self::INFO + ['license' => ['name' => 'MIT', 'identifier' => 'MIT']],
+			'paths' => [],
+		])));
+	}
+
+	public function testComponentConstructsIntroducedLater(): void
+	{
+		Assert::same(['warning components.pathItems'], $this->summarize($this->validate([
+			'openapi' => '3.0.4',
+			'info' => self::INFO,
+			'paths' => [],
+			'components' => ['pathItems' => ['Pet' => ['summary' => 'A pet']]],
+		])));
+
+		Assert::same(['warning components.securitySchemes.mtls.type'], $this->summarize($this->validate([
+			'openapi' => '3.0.4',
+			'info' => self::INFO,
+			'paths' => [],
+			'components' => ['securitySchemes' => ['mtls' => ['type' => 'mutualTLS']]],
+		])));
+	}
+
+	public function testFieldRequiredBeforeItBecameOptional(): void
+	{
+		$problems = $this->validate(['openapi' => '3.0.4', 'info' => self::INFO]);
+
+		Assert::same(['error paths'], $this->summarize($problems));
+		Assert::same(Problem::LEVEL_ERROR, $problems[0]->getLevel());
+	}
+
+	public function testNewerFieldsAreAcceptedInTheirOwnVersion(): void
+	{
+		Assert::same([], $this->validate([
+			'openapi' => '3.1.1',
+			'info' => self::INFO + ['summary' => 'A short summary', 'license' => ['name' => 'MIT', 'identifier' => 'MIT']],
+			'jsonSchemaDialect' => 'https://json-schema.org/draft/2020-12/schema',
+			'webhooks' => ['newPet' => ['summary' => 'New pet']],
+			'components' => [
+				'pathItems' => ['Pet' => ['summary' => 'A pet']],
+				'securitySchemes' => ['mtls' => ['type' => 'mutualTLS']],
+			],
+		]));
+	}
+
+	public function testEveryProblemIsReportedAtOnce(): void
+	{
+		Assert::same([
+			'warning jsonSchemaDialect',
+			'warning info.summary',
+			'error paths',
+		], $this->summarize($this->validate([
+			'openapi' => '3.0.4',
+			'info' => self::INFO + ['summary' => 'A short summary'],
+			'jsonSchemaDialect' => 'https://json-schema.org/draft/2020-12/schema',
+		])));
+	}
+
+	protected function setUp(): void
+	{
+		$this->validator = new VersionValidator();
+	}
+
+	/**
+	 * @param mixed[] $data
+	 * @return Problem[]
+	 */
+	private function validate(array $data): array
+	{
+		return $this->validator->validate(OpenApi::fromArray($data));
+	}
+
+	/**
+	 * @param Problem[] $problems
+	 * @return string[]
+	 */
+	private function summarize(array $problems): array
+	{
+		return array_map(
+			static fn (Problem $problem): string => $problem->getLevel() . ' ' . $problem->getPath(),
+			$problems
+		);
+	}
+
+}
+
+(new VersionValidatorTest())->run();

--- a/tests/Cases/Validator/VersionValidatorTest.php
+++ b/tests/Cases/Validator/VersionValidatorTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Cases\Validator;
 
+use Contributte\OpenApi\Schema\Info;
 use Contributte\OpenApi\Schema\OpenApi;
 use Contributte\OpenApi\Validator\Problem;
 use Contributte\OpenApi\Validator\VersionValidator;
@@ -29,6 +30,17 @@ class VersionValidatorTest extends TestCase
 
 		Assert::same(['warning openapi'], $this->summarize($problems));
 		Assert::contains('2.0', $problems[0]->getMessage());
+	}
+
+	public function testMissingVersionIsReadAsDefault(): void
+	{
+		$openApi = new OpenApi('', Info::fromArray(self::INFO + ['summary' => 'A short summary']));
+
+		Assert::same([
+			'warning openapi',
+			'warning info.summary',
+			'error paths',
+		], $this->summarize($this->validator->validate($openApi)));
 	}
 
 	public function testFieldsIntroducedLater(): void

--- a/tests/Cases/VersionTest.php
+++ b/tests/Cases/VersionTest.php
@@ -40,6 +40,11 @@ class VersionTest extends TestCase
 		Assert::false(Version::isBefore('3.2.0', '3.1'));
 	}
 
+	public function testDefaultIsThreeZero(): void
+	{
+		Assert::same(Version::V3_0, Version::DEFAULT);
+	}
+
 	public function testIsSupported(): void
 	{
 		Assert::true(Version::isSupported('3.0.4'));

--- a/tests/Cases/VersionTest.php
+++ b/tests/Cases/VersionTest.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Cases;
+
+use Contributte\OpenApi\Version;
+use Tester\Assert;
+use Tester\TestCase;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+class VersionTest extends TestCase
+{
+
+	public function testMatchExactVersion(): void
+	{
+		Assert::true(Version::match('3.0.4', '3.0.4'));
+		Assert::false(Version::match('3.0.4', '3.0.3'));
+	}
+
+	public function testMatchWildcard(): void
+	{
+		Assert::true(Version::match('3.0.4', '3.0.x'));
+		Assert::true(Version::match('3.0', '3.0.x'));
+		Assert::true(Version::match('3.1.1', '3.x'));
+		Assert::false(Version::match('3.1.1', '3.0.x'));
+		Assert::false(Version::match('2.0', '3.x'));
+	}
+
+	public function testMatchIgnoresTrailingSegments(): void
+	{
+		Assert::true(Version::match('3.1.1', '3.1'));
+		Assert::false(Version::match('3.1.1', '3.2'));
+	}
+
+	public function testIsBefore(): void
+	{
+		Assert::true(Version::isBefore('3.0.4', '3.1'));
+		Assert::false(Version::isBefore('3.1', '3.1'));
+		Assert::false(Version::isBefore('3.1.1', '3.1'));
+		Assert::false(Version::isBefore('3.2.0', '3.1'));
+	}
+
+	public function testIsSupported(): void
+	{
+		Assert::true(Version::isSupported('3.0.4'));
+		Assert::true(Version::isSupported('3.1.1'));
+		Assert::false(Version::isSupported('3.2.0'));
+		Assert::false(Version::isSupported('2.0'));
+		Assert::false(Version::isSupported('nonsense'));
+	}
+
+}
+
+(new VersionTest())->run();


### PR DESCRIPTION
`OpenApi::$openapi` holds the version the document declares, and nothing ever inspects it. A 3.0 document using `webhooks` or `jsonSchemaDialect` parses silently; a 3.0 document with no `paths` parses too, although 3.0 requires it.

Two new classes, nothing existing changes:

- **`Version`** — version constants and comparison: `Version::match('3.0.4', '3.0.x')`, `Version::isBefore()`, `Version::isSupported()`. A document declaring no version is read as 3.0, the version this library implemented before it could tell versions apart.
- **`Validator\VersionValidator`** — returns a list of `Problem` objects (level, dot-separated path, message):

```php
foreach ((new VersionValidator())->validate($openApi) as $problem) {
	echo $problem; // [warning] webhooks: Attribute "webhooks" was introduced in OpenAPI 3.1, but the document declares 3.0.
}
```

Reported today: an unsupported version; `jsonSchemaDialect`, `webhooks`, `info.summary`, `info.license.identifier`, `components.pathItems` and the `mutualTLS` scheme type in a 3.0 document; a missing `paths`.

The rules are three tables of `path => version`, so a new OpenAPI version means adding rows, not methods. Problems are returned, never thrown — a library has no control over the documents handed to it.

**Tests:** 13 across two new files, including that the same fields raise nothing in a 3.1 document.
