### PR TITLE
fix: keep the content field of parameters and headers

### DIFF
--- a/src/Schema/Header.php
+++ b/src/Schema/Header.php
@@ -26,6 +26,9 @@ class Header
 	/** @var mixed[] */
 	private array $examples = [];
 
+	/** @var MediaType[]|null */
+	private ?array $content = null;
+
 	/**
 	 * @param mixed[] $data
 	 */
@@ -50,6 +53,14 @@ class Header
 
 		$header->setExample($data['example'] ?? null);
 		$header->setExamples($data['examples'] ?? []);
+
+		if (isset($data['content'])) {
+			$header->content = [];
+		}
+
+		foreach ($data['content'] ?? [] as $key => $contentData) {
+			$header->setContent($key, MediaType::fromArray($contentData));
+		}
 
 		return $header;
 	}
@@ -99,6 +110,10 @@ class Header
 
 		if ($this->examples !== []) {
 			$data['examples'] = $this->examples;
+		}
+
+		if ($this->content !== null) {
+			$data['content'] = array_map(static fn (MediaType $mediaType): array => $mediaType->toArray(), $this->content);
 		}
 
 		return $data;
@@ -155,6 +170,11 @@ class Header
 	public function setExamples(array $examples): void
 	{
 		$this->examples = $examples;
+	}
+
+	public function setContent(string $type, MediaType $mediaType): void
+	{
+		$this->content[$type] = $mediaType;
 	}
 
 }

--- a/src/Schema/Parameter.php
+++ b/src/Schema/Parameter.php
@@ -44,6 +44,9 @@ class Parameter
 	/** @var mixed[] */
 	private array $examples = [];
 
+	/** @var MediaType[]|null */
+	private ?array $content = null;
+
 	private ?VendorExtensions $vendorExtensions = null;
 
 	public function __construct(string $name, string $in)
@@ -80,6 +83,14 @@ class Parameter
 			} else {
 				$parameter->setSchema(Schema::fromArray($data['schema']));
 			}
+		}
+
+		if (isset($data['content'])) {
+			$parameter->content = [];
+		}
+
+		foreach ($data['content'] ?? [] as $key => $contentData) {
+			$parameter->setContent($key, MediaType::fromArray($contentData));
 		}
 
 		$parameter->setExample($data['example'] ?? null);
@@ -125,6 +136,11 @@ class Parameter
 	public function setExamples(array $examples): void
 	{
 		$this->examples = $examples;
+	}
+
+	public function setContent(string $type, MediaType $mediaType): void
+	{
+		$this->content[$type] = $mediaType;
 	}
 
 	/**
@@ -176,6 +192,10 @@ class Parameter
 			$data['examples'] = $this->examples;
 		}
 
+		if ($this->content !== null) {
+			$data['content'] = array_map(static fn (MediaType $mediaType): array => $mediaType->toArray(), $this->content);
+		}
+
 		if ($this->vendorExtensions !== null) {
 			$data = array_merge($data, $this->vendorExtensions->toArray());
 		}
@@ -221,6 +241,14 @@ class Parameter
 	public function getExample(): mixed
 	{
 		return $this->example;
+	}
+
+	/**
+	 * @return MediaType[]
+	 */
+	public function getContent(): array
+	{
+		return $this->content ?? [];
 	}
 
 	public function getStyle(): ?string

--- a/tests/Cases/Schema/HeaderTest.php
+++ b/tests/Cases/Schema/HeaderTest.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Cases\Schema;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+use Contributte\OpenApi\Schema\Header;
+use Tester\Assert;
+use Tester\TestCase;
+
+class HeaderTest extends TestCase
+{
+
+	public function testSchema(): void
+	{
+		$expectedData = [
+			'description' => 'The number of allowed requests in the current period',
+			'schema' => ['type' => 'integer'],
+		];
+
+		Assert::same($expectedData, Header::fromArray($expectedData)->toArray());
+	}
+
+	public function testContent(): void
+	{
+		$expectedData = [
+			'description' => 'A structured header',
+			'content' => [
+				'application/json' => ['schema' => ['type' => 'object']],
+			],
+		];
+
+		Assert::same($expectedData, Header::fromArray($expectedData)->toArray());
+	}
+
+}
+
+(new HeaderTest())->run();

--- a/tests/Cases/Schema/ParameterTest.php
+++ b/tests/Cases/Schema/ParameterTest.php
@@ -4,6 +4,7 @@ namespace Tests\Cases\Schema;
 
 require_once __DIR__ . '/../../bootstrap.php';
 
+use Contributte\OpenApi\Schema\MediaType;
 use Contributte\OpenApi\Schema\Parameter;
 use Contributte\OpenApi\Schema\Reference;
 use Contributte\OpenApi\Schema\Schema;
@@ -79,6 +80,22 @@ class ParameterTest extends TestCase
 
 		Assert::same($expectedData, $realData);
 		Assert::same($expectedData, Parameter::fromArray($realData)->toArray());
+	}
+
+	public function testContent(): void
+	{
+		$expectedData = [
+			'name' => 'filter',
+			'in' => 'query',
+			'content' => [
+				'application/json' => ['schema' => ['type' => 'object']],
+			],
+		];
+
+		$parameter = Parameter::fromArray($expectedData);
+
+		Assert::type(MediaType::class, $parameter->getContent()['application/json']);
+		Assert::same($expectedData, $parameter->toArray());
 	}
 
 	public function testInvalidIn(): void


### PR DESCRIPTION
The Parameter Object and the Header Object may describe their value with `content` - a media type map - instead of `schema`. Neither class implements the field, so it is dropped on parse and can never be emitted:

```
Parameter::fromArray(['name' => 'filter', 'in' => 'query', 'content' => [...]])->toArray()
=> {"name":"filter","in":"query"}

Header::fromArray(['description' => 'A header', 'content' => [...]])->toArray()
=> {"description":"A header"}
```

`content` is not new - it is in the Parameter Object and Header Object tables of OAS 3.0.4, 3.1.1 and 3.2.0 alike.

Both classes now hold a `MediaType` map, following the pattern `Response` and `RequestBody` already use. `Parameter` also gains `getContent()`; `Header` keeps its setter-only shape.

**Tests:** `ParameterTest::testContent` and a new `HeaderTest` - the Header Object had no test file before. Both fail against the unmodified code.
