### PR TITLE
feat: support the querystring parameter location and query operation

### DIFF
--- a/src/Schema/Parameter.php
+++ b/src/Schema/Parameter.php
@@ -11,12 +11,14 @@ class Parameter
 	public const IN_HEADER = 'header';
 	public const IN_PATH = 'path';
 	public const IN_QUERY = 'query';
+	public const IN_QUERYSTRING = 'querystring';
 
 	public const INS = [
 		self::IN_COOKIE,
 		self::IN_HEADER,
 		self::IN_PATH,
 		self::IN_QUERY,
+		self::IN_QUERYSTRING,
 	];
 
 	private string $name;

--- a/src/Schema/PathItem.php
+++ b/src/Schema/PathItem.php
@@ -13,6 +13,7 @@ class PathItem
 	public const OPERATION_HEAD = 'head';
 	public const OPERATION_PATCH = 'patch';
 	public const OPERATION_TRACE = 'trace';
+	public const OPERATION_QUERY = 'query';
 
 	/** @var string[] */
 	private static array $allowedOperations = [
@@ -24,6 +25,7 @@ class PathItem
 		self::OPERATION_HEAD,
 		self::OPERATION_PATCH,
 		self::OPERATION_TRACE,
+		self::OPERATION_QUERY,
 	];
 
 	private ?string $summary = null;

--- a/tests/Cases/Schema/ParameterTest.php
+++ b/tests/Cases/Schema/ParameterTest.php
@@ -98,11 +98,27 @@ class ParameterTest extends TestCase
 		Assert::same($expectedData, $parameter->toArray());
 	}
 
+	public function testQuerystringLocation(): void
+	{
+		$expectedData = [
+			'name' => 'query',
+			'in' => 'querystring',
+			'content' => [
+				'application/x-www-form-urlencoded' => ['schema' => ['type' => 'string']],
+			],
+		];
+
+		$parameter = Parameter::fromArray($expectedData);
+
+		Assert::same(Parameter::IN_QUERYSTRING, $parameter->getIn());
+		Assert::same($expectedData, $parameter->toArray());
+	}
+
 	public function testInvalidIn(): void
 	{
 		Assert::exception(static function (): void {
 			new Parameter('foo', 'invalid');
-		}, InvalidArgumentException::class, 'Invalid value "invalid" for attribute "in" given. It must be one of "cookie, header, path, query".');
+		}, InvalidArgumentException::class, 'Invalid value "invalid" for attribute "in" given. It must be one of "cookie, header, path, query, querystring".');
 	}
 
 	public function testSchemaReference(): void

--- a/tests/Cases/Schema/PathItemTest.php
+++ b/tests/Cases/Schema/PathItemTest.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Cases\Schema;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+use Contributte\OpenApi\Schema\PathItem;
+use Tester\Assert;
+use Tester\TestCase;
+
+class PathItemTest extends TestCase
+{
+
+	private const RESPONSES = ['responses' => ['200' => ['description' => 'Success']]];
+
+	public function testOperations(): void
+	{
+		$expectedData = [
+			'get' => self::RESPONSES,
+			'post' => self::RESPONSES,
+		];
+
+		Assert::same($expectedData, PathItem::fromArray($expectedData)->toArray());
+	}
+
+	public function testQueryOperation(): void
+	{
+		$expectedData = [
+			'get' => self::RESPONSES,
+			'query' => self::RESPONSES,
+		];
+
+		Assert::same($expectedData, PathItem::fromArray($expectedData)->toArray());
+	}
+
+}
+
+(new PathItemTest())->run();


### PR DESCRIPTION
OpenAPI 3.2.0 added two constructs this library actively mishandles:

```
Parameter::fromArray(['name' => 'query', 'in' => 'querystring', ...])
=> InvalidArgumentException: Invalid value "querystring" for attribute "in" given.

PathItem::fromArray(['get' => [...], 'query' => [...]])->toArray()
=> {"get":{...}}          // the query operation vanished without a word
```

- **`in: querystring`** treats the whole query string as a single value. It was rejected because the location was not in `Parameter::INS`.
- **The `query` operation** was dropped: `setOperation()` returns early for methods outside its allow list.

Adds `Parameter::IN_QUERYSTRING` and `PathItem::OPERATION_QUERY`. Documents that do not use them are unaffected.

A `querystring` parameter describes itself with `content` rather than `schema`, which #13 made possible.

**Tests:** `ParameterTest::testQuerystringLocation` and a new `PathItemTest`; the existing `testInvalidIn` message now lists the new location.
