### PR TITLE
test: prove OpenAPI 3.0 and 3.1 support, and fix the extension loss it found

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -1,10 +1,11 @@
 # Contributte OpenApi
 
-Pure PHP OpenAPI 3.0 implementation for Nette Framework.
+Pure PHP OpenAPI implementation for Nette Framework, supporting 3.0 and 3.1.
 
 ## Content
 
 - [Setup](#setup)
+- [Supported versions](#supported-versions)
 - [OpenAPI](#tracy)
 - [Version validation](#version-validation)
 - [Tracy](#tracy)
@@ -45,6 +46,18 @@ composer require contributte/openapi
 - [Server.php](../src/Schema/Server.php)
 - [ServerVariable.php](../src/Schema/ServerVariable.php)
 - [Tag.php](../src/Schema/Tag.php)
+
+## Supported versions
+
+| OpenAPI | Support |
+|---------|---------|
+| 3.0     | full    |
+| 3.1     | full    |
+
+Both claims are backed by a test, not by hand: `tests/Cases/VersionSupportTest.php` round-trips
+a complete document per version - one that uses every field the version defines - and requires
+`VersionValidator` to report nothing against it. See `tests/Cases/Schema/examples/complete-3-0.yaml`
+and `complete-3-1.yaml`.
 
 ## Version validation
 

--- a/.docs/README.md
+++ b/.docs/README.md
@@ -51,13 +51,16 @@ composer require contributte/openapi
 
 | OpenAPI | Support |
 |---------|---------|
-| 3.0     | full    |
-| 3.1     | full    |
+| 3.0     | yes     |
+| 3.1     | yes     |
 
-Both claims are backed by a test, not by hand: `tests/Cases/VersionSupportTest.php` round-trips
-a complete document per version - one that uses every field the version defines - and requires
-`VersionValidator` to report nothing against it. See `tests/Cases/Schema/examples/complete-3-0.yaml`
-and `complete-3-1.yaml`.
+`tests/Cases/VersionSupportTest.php` backs both rows with a complete document per version -
+`tests/Cases/Schema/examples/complete-3-0.yaml` and `complete-3-1.yaml` - each using every field
+its version defines, except where the specification makes two fields mutually exclusive and only
+one of them can appear. For each document the test requires that a `fromArray()`/`toArray()` round
+trip loses nothing and that `VersionValidator` reports no problem. For the fields a version
+introduced, it additionally requires the document to exercise them, so a later version cannot be
+called supported while its additions go untested.
 
 ## Version validation
 

--- a/src/Schema/Header.php
+++ b/src/Schema/Header.php
@@ -29,6 +29,8 @@ class Header
 	/** @var MediaType[]|null */
 	private ?array $content = null;
 
+	private ?VendorExtensions $vendorExtensions = null;
+
 	/**
 	 * @param mixed[] $data
 	 */
@@ -61,6 +63,8 @@ class Header
 		foreach ($data['content'] ?? [] as $key => $contentData) {
 			$header->setContent($key, MediaType::fromArray($contentData));
 		}
+
+		$header->setVendorExtensions(VendorExtensions::fromArray($data));
 
 		return $header;
 	}
@@ -114,6 +118,10 @@ class Header
 
 		if ($this->content !== null) {
 			$data['content'] = array_map(static fn (MediaType $mediaType): array => $mediaType->toArray(), $this->content);
+		}
+
+		if ($this->vendorExtensions !== null) {
+			$data = array_merge($data, $this->vendorExtensions->toArray());
 		}
 
 		return $data;
@@ -175,6 +183,16 @@ class Header
 	public function setContent(string $type, MediaType $mediaType): void
 	{
 		$this->content[$type] = $mediaType;
+	}
+
+	public function getVendorExtensions(): ?VendorExtensions
+	{
+		return $this->vendorExtensions;
+	}
+
+	public function setVendorExtensions(?VendorExtensions $vendorExtensions): void
+	{
+		$this->vendorExtensions = $vendorExtensions;
 	}
 
 }

--- a/src/Schema/OAuthFlow.php
+++ b/src/Schema/OAuthFlow.php
@@ -14,6 +14,8 @@ class OAuthFlow
 	/** @var array<string, string> */
 	private array $scopes;
 
+	private ?VendorExtensions $vendorExtensions = null;
+
 	/**
 	 * @param array<string, string> $scopes
 	 */
@@ -35,12 +37,15 @@ class OAuthFlow
 	 */
 	public static function fromArray(array $data): self
 	{
-		return new self(
+		$flow = new self(
 			$data['authorizationUrl'] ?? null,
 			$data['tokenUrl'] ?? null,
 			$data['refreshUrl'] ?? null,
 			$data['scopes'],
 		);
+		$flow->setVendorExtensions(VendorExtensions::fromArray($data));
+
+		return $flow;
 	}
 
 	/**
@@ -63,6 +68,10 @@ class OAuthFlow
 		}
 
 		$data['scopes'] = $this->scopes;
+
+		if ($this->vendorExtensions !== null) {
+			$data = array_merge($data, $this->vendorExtensions->toArray());
+		}
 
 		return $data;
 	}
@@ -111,6 +120,16 @@ class OAuthFlow
 	public function setScopes(array $scopes): void
 	{
 		$this->scopes = $scopes;
+	}
+
+	public function getVendorExtensions(): ?VendorExtensions
+	{
+		return $this->vendorExtensions;
+	}
+
+	public function setVendorExtensions(?VendorExtensions $vendorExtensions): void
+	{
+		$this->vendorExtensions = $vendorExtensions;
 	}
 
 }

--- a/src/Schema/SecurityScheme.php
+++ b/src/Schema/SecurityScheme.php
@@ -60,6 +60,8 @@ class SecurityScheme
 
 	private ?string $openIdConnectUrl = null;
 
+	private ?VendorExtensions $vendorExtensions = null;
+
 	public function __construct(string $type)
 	{
 		$this->setType($type);
@@ -79,6 +81,7 @@ class SecurityScheme
 		$securityScheme->setBearerFormat($data['bearerFormat'] ?? null);
 		$securityScheme->setFlows(array_map(static fn (array $flow): OAuthFlow => OAuthFlow::fromArray($flow), $data['flows'] ?? []));
 		$securityScheme->setOpenIdConnectUrl($data['openIdConnectUrl'] ?? null);
+		$securityScheme->setVendorExtensions(VendorExtensions::fromArray($data));
 
 		return $securityScheme;
 	}
@@ -117,6 +120,10 @@ class SecurityScheme
 
 		if ($this->openIdConnectUrl !== null) {
 			$data['openIdConnectUrl'] = $this->openIdConnectUrl;
+		}
+
+		if ($this->vendorExtensions !== null) {
+			$data = array_merge($data, $this->vendorExtensions->toArray());
 		}
 
 		return $data;
@@ -258,6 +265,16 @@ class SecurityScheme
 		}
 
 		$this->openIdConnectUrl = $openIdConnectUrl;
+	}
+
+	public function getVendorExtensions(): ?VendorExtensions
+	{
+		return $this->vendorExtensions;
+	}
+
+	public function setVendorExtensions(?VendorExtensions $vendorExtensions): void
+	{
+		$this->vendorExtensions = $vendorExtensions;
 	}
 
 	private static function validateFlow(string $flowType, OAuthFlow $flow): void

--- a/src/Validator/VersionValidator.php
+++ b/src/Validator/VersionValidator.php
@@ -22,7 +22,7 @@ class VersionValidator
 	 * Fields and the version that introduced them. A "*" segment matches any key
 	 * of a map.
 	 */
-	private const FIELD_INTRODUCED_IN = [
+	public const FIELD_INTRODUCED_IN = [
 		'jsonSchemaDialect' => Version::V3_1,
 		'webhooks' => Version::V3_1,
 		'info.summary' => Version::V3_1,
@@ -34,7 +34,7 @@ class VersionValidator
 	 * Field values and the version that introduced them, as
 	 * "document path => [value => version]".
 	 */
-	private const VALUE_INTRODUCED_IN = [
+	public const VALUE_INTRODUCED_IN = [
 		'components.securitySchemes.*.type' => [
 			SecurityScheme::TYPE_MUTUAL_TLS => Version::V3_1,
 		],
@@ -43,7 +43,7 @@ class VersionValidator
 	/**
 	 * Required fields and the version that made them optional.
 	 */
-	private const FIELD_OPTIONAL_SINCE = [
+	public const FIELD_OPTIONAL_SINCE = [
 		'paths' => Version::V3_1,
 	];
 

--- a/src/Validator/VersionValidator.php
+++ b/src/Validator/VersionValidator.php
@@ -43,7 +43,7 @@ class VersionValidator
 	/**
 	 * Required fields and the version that made them optional.
 	 */
-	public const FIELD_OPTIONAL_SINCE = [
+	private const FIELD_OPTIONAL_SINCE = [
 		'paths' => Version::V3_1,
 	];
 

--- a/tests/Cases/Schema/HeaderTest.php
+++ b/tests/Cases/Schema/HeaderTest.php
@@ -33,6 +33,19 @@ class HeaderTest extends TestCase
 		Assert::same($expectedData, Header::fromArray($expectedData)->toArray());
 	}
 
+	public function testVendorExtensions(): void
+	{
+		$expectedData = [
+			'description' => 'The number of allowed requests in the current period',
+			'x-internal' => true,
+		];
+
+		$header = Header::fromArray($expectedData);
+
+		Assert::same(true, $header->getVendorExtensions()?->getExtension('x-internal'));
+		Assert::same($expectedData, $header->toArray());
+	}
+
 }
 
 (new HeaderTest())->run();

--- a/tests/Cases/Schema/OAuthFlowTest.php
+++ b/tests/Cases/Schema/OAuthFlowTest.php
@@ -65,6 +65,20 @@ class OAuthFlowTest extends TestCase
 		Assert::same($data, $flow->toArray());
 	}
 
+	public function testVendorExtensions(): void
+	{
+		$expectedData = [
+			'authorizationUrl' => 'https://example.com/authorization',
+			'scopes' => ['read' => 'Read access'],
+			'x-internal' => true,
+		];
+
+		$flow = OAuthFlow::fromArray($expectedData);
+
+		Assert::same(true, $flow->getVendorExtensions()?->getExtension('x-internal'));
+		Assert::same($expectedData, $flow->toArray());
+	}
+
 	/**
 	 * The OpenAPI Specification marks `scopes` as REQUIRED on the OAuth Flow Object (the map MAY
 	 * be empty, but the key MUST be present). fromArray() must not silently manufacture it - a

--- a/tests/Cases/Schema/SecuritySchemeTest.php
+++ b/tests/Cases/Schema/SecuritySchemeTest.php
@@ -116,6 +116,21 @@ class SecuritySchemeTest extends TestCase
 		Assert::same($expected, SecurityScheme::fromArray($array)->toArray());
 	}
 
+	public function testVendorExtensions(): void
+	{
+		$expectedData = [
+			'type' => SecurityScheme::TYPE_API_KEY,
+			'name' => 'api_key',
+			'in' => SecurityScheme::IN_HEADER,
+			'x-internal' => true,
+		];
+
+		$securityScheme = SecurityScheme::fromArray($expectedData);
+
+		Assert::same(true, $securityScheme->getVendorExtensions()?->getExtension('x-internal'));
+		Assert::same($expectedData, $securityScheme->toArray());
+	}
+
 	public function testInvalidType(): void
 	{
 		Assert::exception(static function (): void {

--- a/tests/Cases/Schema/examples/complete-3-0.yaml
+++ b/tests/Cases/Schema/examples/complete-3-0.yaml
@@ -39,8 +39,183 @@ externalDocs:
   url: https://example.com/docs
 x-vendor-flag: true
 paths:
-  /pets:
+  /pets/{petId}:
+    summary: A single pet
+    description: Operations on one pet
+    servers:
+      - url: https://pets.example.com
+    parameters:
+      - name: petId
+        in: path
+        description: Pet identifier
+        required: true
+        deprecated: false
+        style: simple
+        explode: false
+        schema:
+          type: string
+        example: abc123
     get:
+      tags:
+        - pets
+      summary: Read a pet
+      description: Returns a single pet
+      externalDocs:
+        description: Operation documentation
+        url: https://example.com/docs/read-pet
+      operationId: readPet
+      deprecated: true
+      parameters:
+        - name: verbose
+          in: query
+          description: Return the long form
+          required: false
+          allowEmptyValue: true
+          allowReserved: true
+          style: form
+          explode: true
+          schema:
+            type: boolean
+          examples:
+            enabled:
+              summary: Verbose enabled
+              description: Ask for the long form
+              value: true
+        - name: X-Trace
+          in: header
+          required: false
+          style: simple
+          schema:
+            type: string
+        - name: session
+          in: cookie
+          required: false
+          style: form
+          content:
+            application/json:
+              schema:
+                type: object
       responses:
         '200':
-          description: A list of pets
+          description: The pet
+          headers:
+            X-Rate-Limit:
+              description: Calls left this hour
+              required: false
+              deprecated: false
+              style: simple
+              explode: false
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                id: abc123
+              examples:
+                first:
+                  summary: The first pet
+                  value:
+                    id: abc123
+          links:
+            owner:
+              operationId: readOwner
+              parameters:
+                ownerId: $response.body#/ownerId
+              requestBody: $response.body
+              description: The owner of this pet
+              server:
+                url: https://owners.example.com
+                description: Owner service
+        default:
+          description: Unexpected error
+      callbacks:
+        petStatus:
+          '{$request.body#/callbackUrl}':
+            post:
+              requestBody:
+                description: Status update
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      type: object
+              responses:
+                '200':
+                  description: Acknowledged
+      security:
+        - api_key: []
+      servers:
+        - url: https://pets.example.com/v1
+    put:
+      operationId: replacePet
+      requestBody:
+        description: The replacement pet
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: The replaced pet
+    post:
+      operationId: uploadPetPhoto
+      requestBody:
+        description: A multipart upload
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                profile:
+                  type: object
+                avatar:
+                  type: string
+                  format: binary
+            encoding:
+              avatar:
+                contentType: image/png
+                headers:
+                  X-Checksum:
+                    description: Upload checksum
+                    schema:
+                      type: string
+                style: form
+                explode: false
+                allowReserved: false
+      responses:
+        '201':
+          description: Photo stored
+    delete:
+      operationId: deletePet
+      responses:
+        '204':
+          description: Deleted
+    options:
+      operationId: describePet
+      responses:
+        '200':
+          description: Allowed methods
+    head:
+      operationId: checkPet
+      responses:
+        '200':
+          description: Pet exists
+    patch:
+      operationId: updatePet
+      requestBody:
+        content:
+          application/merge-patch+json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: The updated pet
+    trace:
+      operationId: tracePet
+      responses:
+        '200':
+          description: Trace result

--- a/tests/Cases/Schema/examples/complete-3-0.yaml
+++ b/tests/Cases/Schema/examples/complete-3-0.yaml
@@ -138,7 +138,7 @@ paths:
                     id: abc123
           links:
             owner:
-              operationId: readOwner
+              operationId: readPet
               parameters:
                 ownerId: $response.body#/ownerId
               requestBody: $response.body
@@ -325,7 +325,7 @@ components:
       openIdConnectUrl: https://example.com/.well-known/openid-configuration
   links:
     OwnerLink:
-      operationRef: '#/paths/~1owners~1{ownerId}/get'
+      operationRef: '#/paths/~1pets~1{petId}/get'
       parameters:
         ownerId: $response.body#/ownerId
       description: The owner of this pet

--- a/tests/Cases/Schema/examples/complete-3-0.yaml
+++ b/tests/Cases/Schema/examples/complete-3-0.yaml
@@ -239,3 +239,102 @@ paths:
       responses:
         '200':
           description: Trace result
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+        tag:
+          type: string
+  responses:
+    NotFound:
+      description: The pet does not exist
+      content:
+        application/json:
+          schema:
+            type: object
+  parameters:
+    PetIdParameter:
+      name: petId
+      in: path
+      required: true
+      schema:
+        type: string
+  examples:
+    PetExample:
+      summary: An example pet
+      description: A pet with the minimum fields
+      value:
+        id: abc123
+  requestBodies:
+    PetBody:
+      description: A pet to store
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Pet'
+  headers:
+    XRateLimit:
+      description: Calls left this hour
+      schema:
+        type: integer
+  securitySchemes:
+    api_key:
+      type: apiKey
+      description: Key based authentication
+      name: api_key
+      in: header
+    basic_auth:
+      type: http
+      description: Basic authentication
+      scheme: basic
+    bearer_auth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+    petstore_auth:
+      type: oauth2
+      description: OAuth 2 authentication
+      flows:
+        implicit:
+          authorizationUrl: https://example.com/oauth/authorize
+          refreshUrl: https://example.com/oauth/refresh
+          scopes:
+            read:pets: Read pets
+        password:
+          tokenUrl: https://example.com/oauth/token
+          refreshUrl: https://example.com/oauth/refresh
+          scopes:
+            read:pets: Read pets
+        clientCredentials:
+          tokenUrl: https://example.com/oauth/token
+          scopes:
+            write:pets: Write pets
+        authorizationCode:
+          authorizationUrl: https://example.com/oauth/authorize
+          tokenUrl: https://example.com/oauth/token
+          refreshUrl: https://example.com/oauth/refresh
+          scopes:
+            read:pets: Read pets
+            write:pets: Write pets
+    openid_auth:
+      type: openIdConnect
+      openIdConnectUrl: https://example.com/.well-known/openid-configuration
+  links:
+    OwnerLink:
+      operationRef: '#/paths/~1owners~1{ownerId}/get'
+      parameters:
+        ownerId: $response.body#/ownerId
+      description: The owner of this pet
+  callbacks:
+    PetStatusCallback:
+      '{$request.body#/callbackUrl}':
+        post:
+          responses:
+            '200':
+              description: Acknowledged

--- a/tests/Cases/Schema/examples/complete-3-0.yaml
+++ b/tests/Cases/Schema/examples/complete-3-0.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.3"
 info:
   title: Complete 3.0 document
-  description: Uses every field OpenAPI 3.0 defines.
+  description: Uses every field OpenAPI 3.0 defines, except where two fields exclude each other.
   termsOfService: https://example.com/terms
   contact:
     name: API Support

--- a/tests/Cases/Schema/examples/complete-3-0.yaml
+++ b/tests/Cases/Schema/examples/complete-3-0.yaml
@@ -1,7 +1,43 @@
 openapi: "3.0.4"
 info:
   title: Complete 3.0 document
+  description: Uses every field OpenAPI 3.0 defines.
+  termsOfService: https://example.com/terms
+  contact:
+    name: API Support
+    url: https://example.com/support
+    email: support@example.com
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
   version: 1.0.0
+servers:
+  - url: https://{region}.example.com/{version}
+    description: Regional server
+    variables:
+      region:
+        enum:
+          - eu
+          - us
+        default: eu
+        description: Data region
+      version:
+        default: v1
+security:
+  - api_key: []
+  - petstore_auth:
+      - read:pets
+      - write:pets
+tags:
+  - name: pets
+    description: Everything about pets
+    externalDocs:
+      description: Pet documentation
+      url: https://example.com/docs/pets
+externalDocs:
+  description: Full documentation
+  url: https://example.com/docs
+x-vendor-flag: true
 paths:
   /pets:
     get:

--- a/tests/Cases/Schema/examples/complete-3-0.yaml
+++ b/tests/Cases/Schema/examples/complete-3-0.yaml
@@ -103,8 +103,6 @@ paths:
               description: Calls left this hour
               required: false
               deprecated: false
-              allowEmptyValue: false
-              allowReserved: false
               style: simple
               explode: false
               schema:

--- a/tests/Cases/Schema/examples/complete-3-0.yaml
+++ b/tests/Cases/Schema/examples/complete-3-0.yaml
@@ -1,4 +1,4 @@
-openapi: "3.0.4"
+openapi: "3.0.3"
 info:
   title: Complete 3.0 document
   description: Uses every field OpenAPI 3.0 defines.

--- a/tests/Cases/Schema/examples/complete-3-0.yaml
+++ b/tests/Cases/Schema/examples/complete-3-0.yaml
@@ -108,6 +108,7 @@ paths:
               schema:
                 type: integer
               example: 42
+              x-internal: true
             X-Trace-Id:
               description: Trace identifier
               required: false
@@ -287,6 +288,7 @@ components:
       description: Key based authentication
       name: api_key
       in: header
+      x-internal: true
     basic_auth:
       type: http
       description: Basic authentication
@@ -304,6 +306,7 @@ components:
           refreshUrl: https://example.com/oauth/refresh
           scopes:
             read:pets: Read pets
+          x-internal: true
         password:
           tokenUrl: https://example.com/oauth/token
           refreshUrl: https://example.com/oauth/refresh

--- a/tests/Cases/Schema/examples/complete-3-0.yaml
+++ b/tests/Cases/Schema/examples/complete-3-0.yaml
@@ -1,0 +1,10 @@
+openapi: "3.0.4"
+info:
+  title: Complete 3.0 document
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      responses:
+        '200':
+          description: A list of pets

--- a/tests/Cases/Schema/examples/complete-3-0.yaml
+++ b/tests/Cases/Schema/examples/complete-3-0.yaml
@@ -103,10 +103,30 @@ paths:
               description: Calls left this hour
               required: false
               deprecated: false
+              allowEmptyValue: false
+              allowReserved: false
               style: simple
               explode: false
               schema:
                 type: integer
+              example: 42
+            X-Trace-Id:
+              description: Trace identifier
+              required: false
+              style: simple
+              schema:
+                type: string
+              examples:
+                main:
+                  summary: Main trace
+                  value: trace-12345
+            X-Session-Info:
+              description: Session information
+              required: false
+              content:
+                application/json:
+                  schema:
+                    type: object
           content:
             application/json:
               schema:

--- a/tests/Cases/Schema/examples/complete-3-1.yaml
+++ b/tests/Cases/Schema/examples/complete-3-1.yaml
@@ -1,4 +1,4 @@
-openapi: "3.1.1"
+openapi: "3.1.0"
 jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
 info:
   title: Complete 3.1 document

--- a/tests/Cases/Schema/examples/complete-3-1.yaml
+++ b/tests/Cases/Schema/examples/complete-3-1.yaml
@@ -2,25 +2,44 @@ openapi: "3.1.1"
 jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
 info:
   title: Complete 3.1 document
-  summary: Uses every field OpenAPI 3.1 defines.
-  version: 1.0.0
+  summary: A complete 3.1 document.
+  description: Uses every field OpenAPI 3.1 defines.
+  termsOfService: https://example.com/terms
+  contact:
+    name: API Support
+    url: https://example.com/support
+    email: support@example.com
   license:
     name: MIT
     identifier: MIT
-paths:
-  /pets:
-    get:
-      responses:
-        '200':
-          description: A list of pets
-          content:
-            application/json:
-              schema:
-                type: [array, "null"]
-                prefixItems:
-                  - type: string
-                unevaluatedProperties: false
-                contentMediaType: application/json
+  version: 1.0.0
+servers:
+  - url: https://{region}.example.com/{version}
+    description: Regional server
+    variables:
+      region:
+        enum:
+          - eu
+          - us
+        default: eu
+        description: Data region
+      version:
+        default: v1
+security:
+  - api_key: []
+  - petstore_auth:
+      - read:pets
+      - write:pets
+tags:
+  - name: pets
+    description: Everything about pets
+    externalDocs:
+      description: Pet documentation
+      url: https://example.com/docs/pets
+externalDocs:
+  description: Full documentation
+  url: https://example.com/docs
+x-vendor-flag: true
 webhooks:
   petCreated:
     post:
@@ -37,6 +56,192 @@ webhooks:
     $ref: '#/components/pathItems/petEvent'
     summary: Reference summary
     description: Reference description
+paths:
+  /pets/{petId}:
+    summary: A single pet
+    description: Operations on one pet
+    servers:
+      - url: https://pets.example.com
+    parameters:
+      - name: petId
+        in: path
+        description: Pet identifier
+        required: true
+        deprecated: false
+        style: simple
+        explode: false
+        schema:
+          type: string
+        example: abc123
+    get:
+      tags:
+        - pets
+      summary: Read a pet
+      description: Returns a single pet
+      externalDocs:
+        description: Operation documentation
+        url: https://example.com/docs/read-pet
+      operationId: readPet
+      deprecated: true
+      parameters:
+        - name: verbose
+          in: query
+          description: Return the long form
+          required: false
+          allowEmptyValue: true
+          allowReserved: true
+          style: form
+          explode: true
+          schema:
+            type: boolean
+          examples:
+            enabled:
+              summary: Verbose enabled
+              description: Ask for the long form
+              value: true
+        - name: X-Trace
+          in: header
+          required: false
+          style: simple
+          schema:
+            type: string
+        - name: session
+          in: cookie
+          required: false
+          style: form
+          content:
+            application/json:
+              schema:
+                type: object
+      responses:
+        '200':
+          description: The pet
+          headers:
+            X-Rate-Limit:
+              description: Calls left this hour
+              required: false
+              deprecated: false
+              style: simple
+              explode: false
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: [object, "null"]
+                const: null
+                prefixItems:
+                  - type: string
+                unevaluatedProperties: false
+                contentMediaType: application/json
+              example:
+                id: abc123
+              examples:
+                first:
+                  summary: The first pet
+                  value:
+                    id: abc123
+          links:
+            owner:
+              operationId: readOwner
+              parameters:
+                ownerId: $response.body#/ownerId
+              requestBody: $response.body
+              description: The owner of this pet
+              server:
+                url: https://owners.example.com
+                description: Owner service
+        default:
+          description: Unexpected error
+      callbacks:
+        petStatus:
+          '{$request.body#/callbackUrl}':
+            post:
+              requestBody:
+                description: Status update
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      type: object
+              responses:
+                '200':
+                  description: Acknowledged
+      security:
+        - api_key: []
+      servers:
+        - url: https://pets.example.com/v1
+    put:
+      operationId: replacePet
+      requestBody:
+        description: The replacement pet
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: The replaced pet
+    post:
+      operationId: uploadPetPhoto
+      requestBody:
+        description: A multipart upload
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                profile:
+                  type: object
+                avatar:
+                  type: string
+                  format: binary
+            encoding:
+              avatar:
+                contentType: image/png
+                headers:
+                  X-Checksum:
+                    description: Upload checksum
+                    schema:
+                      type: string
+                style: form
+                explode: false
+                allowReserved: false
+      responses:
+        '201':
+          description: Photo stored
+    delete:
+      operationId: deletePet
+      responses:
+        '204':
+          description: Deleted
+    options:
+      operationId: describePet
+      responses:
+        '200':
+          description: Allowed methods
+    head:
+      operationId: checkPet
+      responses:
+        '200':
+          description: Pet exists
+    patch:
+      operationId: updatePet
+      requestBody:
+        content:
+          application/merge-patch+json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: The updated pet
+    trace:
+      operationId: tracePet
+      responses:
+        '200':
+          description: Trace result
 components:
   pathItems:
     petEvent:
@@ -44,7 +249,104 @@ components:
         responses:
           '200':
             description: Acknowledged
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+        tag:
+          type: string
+  responses:
+    NotFound:
+      description: The pet does not exist
+      content:
+        application/json:
+          schema:
+            type: object
+  parameters:
+    PetIdParameter:
+      name: petId
+      in: path
+      required: true
+      schema:
+        type: string
+  examples:
+    PetExample:
+      summary: An example pet
+      description: A pet with the minimum fields
+      value:
+        id: abc123
+  requestBodies:
+    PetBody:
+      description: A pet to store
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Pet'
+  headers:
+    XRateLimit:
+      description: Calls left this hour
+      schema:
+        type: integer
   securitySchemes:
+    api_key:
+      type: apiKey
+      description: Key based authentication
+      name: api_key
+      in: header
+    basic_auth:
+      type: http
+      description: Basic authentication
+      scheme: basic
+    bearer_auth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
     mtls:
       type: mutualTLS
       description: Client certificate authentication
+    petstore_auth:
+      type: oauth2
+      description: OAuth 2 authentication
+      flows:
+        implicit:
+          authorizationUrl: https://example.com/oauth/authorize
+          refreshUrl: https://example.com/oauth/refresh
+          scopes:
+            read:pets: Read pets
+        password:
+          tokenUrl: https://example.com/oauth/token
+          refreshUrl: https://example.com/oauth/refresh
+          scopes:
+            read:pets: Read pets
+        clientCredentials:
+          tokenUrl: https://example.com/oauth/token
+          scopes:
+            write:pets: Write pets
+        authorizationCode:
+          authorizationUrl: https://example.com/oauth/authorize
+          tokenUrl: https://example.com/oauth/token
+          refreshUrl: https://example.com/oauth/refresh
+          scopes:
+            read:pets: Read pets
+            write:pets: Write pets
+    openid_auth:
+      type: openIdConnect
+      openIdConnectUrl: https://example.com/.well-known/openid-configuration
+  links:
+    OwnerLink:
+      operationRef: '#/paths/~1owners~1{ownerId}/get'
+      parameters:
+        ownerId: $response.body#/ownerId
+      description: The owner of this pet
+  callbacks:
+    PetStatusCallback:
+      '{$request.body#/callbackUrl}':
+        post:
+          responses:
+            '200':
+              description: Acknowledged

--- a/tests/Cases/Schema/examples/complete-3-1.yaml
+++ b/tests/Cases/Schema/examples/complete-3-1.yaml
@@ -1,5 +1,5 @@
 openapi: "3.1.0"
-jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
+jsonSchemaDialect: https://spec.openapis.org/oas/3.1/dialect/base
 info:
   title: Complete 3.1 document
   summary: A complete 3.1 document.

--- a/tests/Cases/Schema/examples/complete-3-1.yaml
+++ b/tests/Cases/Schema/examples/complete-3-1.yaml
@@ -1,0 +1,10 @@
+openapi: "3.1.1"
+info:
+  title: Complete 3.1 document
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      responses:
+        '200':
+          description: A list of pets

--- a/tests/Cases/Schema/examples/complete-3-1.yaml
+++ b/tests/Cases/Schema/examples/complete-3-1.yaml
@@ -147,9 +147,11 @@ paths:
             application/json:
               schema:
                 type: [object, "null"]
-                const: null
-                prefixItems:
-                  - type: string
+                properties:
+                  history:
+                    type: array
+                    prefixItems:
+                      - type: string
                 unevaluatedProperties: false
                 contentMediaType: application/json
               example:

--- a/tests/Cases/Schema/examples/complete-3-1.yaml
+++ b/tests/Cases/Schema/examples/complete-3-1.yaml
@@ -1,10 +1,50 @@
 openapi: "3.1.1"
+jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
 info:
   title: Complete 3.1 document
+  summary: Uses every field OpenAPI 3.1 defines.
   version: 1.0.0
+  license:
+    name: MIT
+    identifier: MIT
 paths:
   /pets:
     get:
       responses:
         '200':
           description: A list of pets
+          content:
+            application/json:
+              schema:
+                type: [array, "null"]
+                prefixItems:
+                  - type: string
+                unevaluatedProperties: false
+                contentMediaType: application/json
+webhooks:
+  petCreated:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              const: null
+      responses:
+        '200':
+          description: Acknowledged
+  petDeleted:
+    $ref: '#/components/pathItems/petEvent'
+    summary: Reference summary
+    description: Reference description
+components:
+  pathItems:
+    petEvent:
+      post:
+        responses:
+          '200':
+            description: Acknowledged
+  securitySchemes:
+    mtls:
+      type: mutualTLS
+      description: Client certificate authentication

--- a/tests/Cases/Schema/examples/complete-3-1.yaml
+++ b/tests/Cases/Schema/examples/complete-3-1.yaml
@@ -3,7 +3,7 @@ jsonSchemaDialect: https://spec.openapis.org/oas/3.1/dialect/base
 info:
   title: Complete 3.1 document
   summary: A complete 3.1 document.
-  description: Uses every field OpenAPI 3.1 defines.
+  description: Uses every field OpenAPI 3.1 defines, except where two fields exclude each other.
   termsOfService: https://example.com/terms
   contact:
     name: API Support

--- a/tests/Cases/Schema/examples/complete-3-1.yaml
+++ b/tests/Cases/Schema/examples/complete-3-1.yaml
@@ -161,7 +161,7 @@ paths:
                     id: abc123
           links:
             owner:
-              operationId: readOwner
+              operationId: readPet
               parameters:
                 ownerId: $response.body#/ownerId
               requestBody: $response.body
@@ -357,7 +357,7 @@ components:
       openIdConnectUrl: https://example.com/.well-known/openid-configuration
   links:
     OwnerLink:
-      operationRef: '#/paths/~1owners~1{ownerId}/get'
+      operationRef: '#/paths/~1pets~1{petId}/get'
       parameters:
         ownerId: $response.body#/ownerId
       description: The owner of this pet

--- a/tests/Cases/Schema/examples/complete-3-1.yaml
+++ b/tests/Cases/Schema/examples/complete-3-1.yaml
@@ -121,8 +121,6 @@ paths:
               description: Calls left this hour
               required: false
               deprecated: false
-              allowEmptyValue: false
-              allowReserved: false
               style: simple
               explode: false
               schema:

--- a/tests/Cases/Schema/examples/complete-3-1.yaml
+++ b/tests/Cases/Schema/examples/complete-3-1.yaml
@@ -126,6 +126,7 @@ paths:
               schema:
                 type: integer
               example: 42
+              x-internal: true
             X-Trace-Id:
               description: Trace identifier
               required: false
@@ -318,6 +319,7 @@ components:
       description: Key based authentication
       name: api_key
       in: header
+      x-internal: true
     basic_auth:
       type: http
       description: Basic authentication
@@ -338,6 +340,7 @@ components:
           refreshUrl: https://example.com/oauth/refresh
           scopes:
             read:pets: Read pets
+          x-internal: true
         password:
           tokenUrl: https://example.com/oauth/token
           refreshUrl: https://example.com/oauth/refresh

--- a/tests/Cases/Schema/examples/complete-3-1.yaml
+++ b/tests/Cases/Schema/examples/complete-3-1.yaml
@@ -121,10 +121,30 @@ paths:
               description: Calls left this hour
               required: false
               deprecated: false
+              allowEmptyValue: false
+              allowReserved: false
               style: simple
               explode: false
               schema:
                 type: integer
+              example: 42
+            X-Trace-Id:
+              description: Trace identifier
+              required: false
+              style: simple
+              schema:
+                type: string
+              examples:
+                main:
+                  summary: Main trace
+                  value: trace-12345
+            X-Session-Info:
+              description: Session information
+              required: false
+              content:
+                application/json:
+                  schema:
+                    type: object
           content:
             application/json:
               schema:

--- a/tests/Cases/VersionSupportTest.php
+++ b/tests/Cases/VersionSupportTest.php
@@ -5,6 +5,7 @@ namespace Tests\Cases;
 require_once __DIR__ . '/../bootstrap.php';
 
 use Contributte\OpenApi\Schema\OpenApi;
+use Contributte\OpenApi\Validator\VersionValidator;
 use Contributte\OpenApi\Version;
 use Symfony\Component\Yaml\Yaml;
 use Tester\Assert;
@@ -52,6 +53,12 @@ final class VersionSupportTest extends TestCase
 		$openApi = OpenApi::fromArray($rawData);
 
 		self::assertSameDataStructure($rawData, $openApi->toArray(), $version);
+
+		Assert::same(
+			[],
+			array_map(strval(...), (new VersionValidator())->validate($openApi)),
+			sprintf('document of version %s raises no version problem', $version)
+		);
 	}
 
 	/**

--- a/tests/Cases/VersionSupportTest.php
+++ b/tests/Cases/VersionSupportTest.php
@@ -1,0 +1,95 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Cases;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+use Contributte\OpenApi\Schema\OpenApi;
+use Contributte\OpenApi\Version;
+use Symfony\Component\Yaml\Yaml;
+use Tester\Assert;
+use Tester\TestCase;
+
+/**
+ * Proves the library supports each OpenAPI version it claims to support.
+ *
+ * Every supported version has one complete document - a document using every field that
+ * version defines. Real-world examples only use the fields their authors needed, so they
+ * cannot carry that proof; see ExamplesTest for those.
+ */
+final class VersionSupportTest extends TestCase
+{
+
+	private const DOCUMENT_DIRECTORY = __DIR__ . '/Schema/examples/';
+
+	// Complete document of each supported version, as "version => file name".
+	private const COMPLETE_DOCUMENTS = [
+		Version::V3_0 => 'complete-3-0.yaml',
+		Version::V3_1 => 'complete-3-1.yaml',
+	];
+
+	/**
+	 * @return array<string, array{string, string}>
+	 */
+	public function provideCompleteDocuments(): array
+	{
+		$rows = [];
+
+		foreach (self::COMPLETE_DOCUMENTS as $version => $file) {
+			$rows[$version] = [$version, $file];
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * @dataProvider provideCompleteDocuments
+	 */
+	public function testCompleteDocument(string $version, string $file): void
+	{
+		$rawData = Yaml::parseFile(self::DOCUMENT_DIRECTORY . $file);
+
+		$openApi = OpenApi::fromArray($rawData);
+
+		self::assertSameDataStructure($rawData, $openApi->toArray(), $version);
+	}
+
+	/**
+	 * @param mixed[] $expected
+	 * @param mixed[] $actual
+	 */
+	private static function assertSameDataStructure(array $expected, array $actual, string $version): void
+	{
+		Assert::same(
+			self::recursiveSort($expected),
+			self::recursiveSort($actual),
+			sprintf('document of version %s survives a round trip', $version)
+		);
+	}
+
+	/**
+	 * Key order carries no meaning in an OpenAPI document, so both sides are sorted before
+	 * they are compared.
+	 *
+	 * @param mixed[] $data
+	 * @return mixed[]
+	 */
+	private static function recursiveSort(array $data): array
+	{
+		foreach ($data as $key => $value) {
+			if (!is_array($value)) {
+				continue;
+			}
+
+			$data[$key] = self::recursiveSort($value);
+		}
+
+		unset($value);
+		ksort($data);
+
+		return $data;
+	}
+
+}
+
+(new VersionSupportTest())->run();

--- a/tests/Cases/VersionSupportTest.php
+++ b/tests/Cases/VersionSupportTest.php
@@ -5,6 +5,7 @@ namespace Tests\Cases;
 require_once __DIR__ . '/../bootstrap.php';
 
 use Contributte\OpenApi\Schema\OpenApi;
+use Contributte\OpenApi\Validator\Problem;
 use Contributte\OpenApi\Validator\VersionValidator;
 use Contributte\OpenApi\Version;
 use Symfony\Component\Yaml\Yaml;
@@ -59,6 +60,37 @@ final class VersionSupportTest extends TestCase
 			array_map(strval(...), (new VersionValidator())->validate($openApi)),
 			sprintf('document of version %s raises no version problem', $version)
 		);
+
+		$expectedPaths = self::expectedPaths($version);
+
+		if ($expectedPaths === []) {
+			return;
+		}
+
+		$rawData['openapi'] = Version::SUPPORTED[0];
+		$reported = array_map(
+			static fn (Problem $problem): string => $problem->getPath(),
+			(new VersionValidator())->validate(OpenApi::fromArray($rawData))
+		);
+
+		$uncovered = array_values(array_filter(
+			$expectedPaths,
+			static function (string $pattern) use ($reported): bool {
+				foreach ($reported as $path) {
+					if (self::matchesPath($pattern, $path)) {
+						return false;
+					}
+				}
+
+				return true;
+			}
+		));
+
+		Assert::same(
+			[],
+			$uncovered,
+			sprintf('document of version %s exercises every field that version introduced', $version)
+		);
 	}
 
 	/**
@@ -95,6 +127,48 @@ final class VersionSupportTest extends TestCase
 		ksort($data);
 
 		return $data;
+	}
+
+	/**
+	 * Rule paths a document of this version must exercise: everything introduced after the
+	 * oldest supported version, up to and including this one. The validator's tables are the
+	 * list of what the library knows about versions, so they double as the coverage list.
+	 *
+	 * @return string[]
+	 */
+	private static function expectedPaths(string $version): array
+	{
+		$oldest = Version::SUPPORTED[0];
+		$paths = [];
+
+		$introducedIn = VersionValidator::FIELD_INTRODUCED_IN;
+
+		foreach (VersionValidator::VALUE_INTRODUCED_IN as $path => $values) {
+			foreach ($values as $introduced) {
+				$introducedIn[$path] = $introduced;
+			}
+		}
+
+		foreach ($introducedIn as $path => $introduced) {
+			if (Version::isBefore($oldest, $introduced) && !Version::isBefore($version, $introduced)) {
+				$paths[] = $path;
+			}
+		}
+
+		sort($paths);
+
+		return $paths;
+	}
+
+	/**
+	 * Whether a concrete document path matches a rule path, whose "*" segment stands for any
+	 * single key of a map.
+	 */
+	private static function matchesPath(string $pattern, string $path): bool
+	{
+		$regex = '#^' . str_replace('\*', '[^.]+', preg_quote($pattern, '#')) . '$#';
+
+		return preg_match($regex, $path) === 1;
 	}
 
 }

--- a/tests/Cases/VersionSupportTest.php
+++ b/tests/Cases/VersionSupportTest.php
@@ -134,27 +134,37 @@ final class VersionSupportTest extends TestCase
 	 * oldest supported version, up to and including this one. The validator's tables are the
 	 * list of what the library knows about versions, so they double as the coverage list.
 	 *
+	 * Both tables contribute "(path, introducedIn)" pairs to a flat list rather than a
+	 * path-keyed map, so a path that carries several values introduced in different versions
+	 * cannot have one overwrite another before the version filter runs.
+	 *
 	 * @return string[]
 	 */
 	private static function expectedPaths(string $version): array
 	{
 		$oldest = Version::SUPPORTED[0];
-		$paths = [];
 
-		$introducedIn = VersionValidator::FIELD_INTRODUCED_IN;
+		$pairs = [];
+
+		foreach (VersionValidator::FIELD_INTRODUCED_IN as $path => $introduced) {
+			$pairs[] = [$path, $introduced];
+		}
 
 		foreach (VersionValidator::VALUE_INTRODUCED_IN as $path => $values) {
 			foreach ($values as $introduced) {
-				$introducedIn[$path] = $introduced;
+				$pairs[] = [$path, $introduced];
 			}
 		}
 
-		foreach ($introducedIn as $path => $introduced) {
+		$paths = [];
+
+		foreach ($pairs as [$path, $introduced]) {
 			if (Version::isBefore($oldest, $introduced) && !Version::isBefore($version, $introduced)) {
-				$paths[] = $path;
+				$paths[$path] = true;
 			}
 		}
 
+		$paths = array_keys($paths);
 		sort($paths);
 
 		return $paths;


### PR DESCRIPTION
The test suite round-trips eleven real-world documents, seven declaring 3.0 and four declaring
3.1. Being real-world documents, they only use the fields their authors needed, so three 3.1
additions are exercised by nothing at all:

| 3.1 addition | Covered before this pull request? |
| --- | --- |
| `webhooks` | yes, `webhook-example.yaml` |
| `jsonSchemaDialect` | no |
| `type: mutualTLS` | no |
| `components.pathItems` | no |

The library implements all of them - but nothing in the repository proved it, and `.docs/README.md`
still described the package as a 3.0 implementation.

This adds one *complete* document per supported version, each using every field its version
defines, and a test making three assertions about it:

1. `fromArray()` followed by `toArray()` returns the document unchanged.
2. `VersionValidator` reports no problem against the version the document declares.
3. Every field the validator records as introduced in that version actually appears in the
   document. This works by relabelling the document to the oldest supported version and requiring
   the validator to complain about each one, so the test needs no copy of the validator's path
   resolution.

The third assertion is why `FIELD_INTRODUCED_IN` and `VALUE_INTRODUCED_IN` became `public const` -
the only visibility change in `src/`. They are declarative data describing what the library knows
about versions, which is what a coverage assertion needs to read. Reflection would couple the test
invisibly; restating the list in the test would let it drift.

**The complete documents immediately found a bug.** Specification extensions were being dropped on
three objects that OpenAPI allows them on:

```
MISSING ...responses.200.headers.X-Rate-Limit.x-internal
MISSING components.securitySchemes.api_key.x-internal
MISSING components.securitySchemes.petstore_auth.flows.implicit.x-internal
```

`Header`, `SecurityScheme` and `OAuthFlow` had no `VendorExtensions` support at all - the same
defect that was already fixed for `Contact`, surviving in three more classes. It is fixed here, each
with a test that reproduces the loss first, and both fixtures now carry `x-` keys on those objects
so the round trip guards them from now on. Every other extensible object was checked and is clean.

The practical effect of assertion 3: when 3.2 support lands, it fails until `complete-3-2.yaml`
exercises the new fields. Completeness of future documents is enforced by the test, not by reviewer
memory.

3.2 is deliberately absent from the version table. `Parameter::IN_QUERYSTRING` and
`PathItem::OPERATION_QUERY` are proposed separately in #14, but without a complete 3.2 document the
claim would be unproven - the very problem this pull request fixes.

The documentation states only what the test enforces, including the one caveat that "every field"
cannot be taken literally: the specification makes some fields mutually exclusive, so no single
document can carry both `license.identifier` and `license.url`.

**Would you consider tagging a release once this is in master?** With 3.0 and 3.1 support now backed
by tests, plus #10-#13 already merged, there is a meaningful amount of unreleased work on `master`.
